### PR TITLE
chore: add `extends` field and remove duplicated fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "description": "A comprehensive UI library for React, built with Tailwind CSS and CVA (Class Variance Authority). It provides reusable components and supports JSX syntax.",
   "scripts": {
+    "build:ui": "npm run build --workspaces",
     "format": "npx prettier --write . --workspaces",
     "format:check": "npx prettier --check . --workspaces"
   },

--- a/packages/button/tsconfig.json
+++ b/packages/button/tsconfig.json
@@ -1,21 +1,8 @@
 {
-  "display": "Node 20",
-  "_version": "20.1.0",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["ES2022", "DOM"],
-    "target": "ES2022",
-    "declaration": true,
-    "jsx": "preserve",
     "outDir": "dist",
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "moduleDetection": "force",
-    "allowJs": true,
-    "checkJs": true,
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": true
+    "rootDir": "src"
   },
   "exclude": ["dist"],
   "include": ["src"]

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -11,5 +11,5 @@ import { twMerge } from "tw-merge"
  * merge("text-blue-500 text-red-500")
  */
 export const merge = (...classes: ClassValue[]): string => {
-	return twMerge(clsx(classes))
+	return twMerge(clsx(classes.filter(Boolean)))
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,21 +1,8 @@
 {
-  "display": "Node 20",
-  "_version": "20.1.0",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["ES2022", "DOM"],
-    "target": "ES2022",
-    "declaration": true,
-    "jsx": "preserve",
     "outDir": "dist",
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "moduleDetection": "force",
-    "allowJs": true,
-    "checkJs": true,
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": true
+    "rootDir": "src"
   },
   "exclude": ["dist"],
   "include": ["src"]


### PR DESCRIPTION
## Description
This pull request introduces the `extends` field in the monorepo packages, including `core` and `button`, to streamline the configuration of `tsconfig.json` files based on the top-level configuration. Additionally, a new script has been added to package.json for building all projects within the monorepo folder.

## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->