### PR TITLE
chore: update `printWidth` property for tsx files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,5 +3,6 @@ node_modules
 
 # files
 package-lock.json
+pnpm-lock.yaml
 LICENSE
 .gitignore

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -10,8 +10,18 @@ const getAbsolutePath = (value: string): string => {
 }
 
 const config: StorybookConfig = {
-	stories: ["../stories/**/*.mdx", "../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)", "../packages/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
-	addons: [getAbsolutePath("@storybook/addon-onboarding"), getAbsolutePath("@storybook/addon-links"), getAbsolutePath("@storybook/addon-essentials"), getAbsolutePath("@chromatic-com/storybook"), getAbsolutePath("@storybook/addon-interactions")],
+	stories: [
+		"../stories/**/*.mdx",
+		"../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+		"../packages/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+	],
+	addons: [
+		getAbsolutePath("@storybook/addon-onboarding"),
+		getAbsolutePath("@storybook/addon-links"),
+		getAbsolutePath("@storybook/addon-essentials"),
+		getAbsolutePath("@chromatic-com/storybook"),
+		getAbsolutePath("@storybook/addon-interactions"),
+	],
 	framework: {
 		name: getAbsolutePath("@storybook/react-vite"),
 		options: {},

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "semi": false,
     "jsxSingleQuote": false,
     "singleQuote": false,
-    "printWidth": 300,
+    "printWidth": 120,
     "tabWidth": 4,
     "useTabs": true,
     "trailingComma": "es5",
@@ -92,6 +92,14 @@
         "options": {
           "tabWidth": 2,
           "useTabs": false
+        }
+      },
+      {
+        "files": [
+          "**/*.tsx"
+        ],
+        "options": {
+          "printWidth": 300
         }
       }
     ]

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,14 +1,7 @@
 import type { Config } from "tailwindcss"
 
-// prettier-ignore
 const config: Config = {
-	content: [
-		"./ui/**/*.{js,ts,jsx,tsx,mdx}", 
-		"./app/**/*.{js,ts,jsx,tsx,mdx}", 
-		"./packages/**/*.{js,ts,jsx,tsx,mdx}",
-		"./node_modules/**/*.{js,ts,jsx,tsx,mdx}",
-		"./node_modules/@halvaradop/**/*.{js,ts,jsx,tsx,mdx}",
-	],
+	content: ["./ui/**/*.{js,ts,jsx,tsx,mdx}", "./app/**/*.{js,ts,jsx,tsx,mdx}", "./packages/**/*.{js,ts,jsx,tsx,mdx}"],
 	darkMode: "class",
 	future: {
 		hoverOnlyWhenSupported: true,


### PR DESCRIPTION
## Description
This pull request updates the `printWidth` property for Prettier in `package.json`, reducing the value from 300 to 120, and mantein 300 value for `.tsx` files.

The change aims to improve code formatting for configuration files and other scripts by keeping lines concise, while allowing `.tsx` files to accommodate longer lines due to the complexity of React components and their configurations.

## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->