### PR TITLE
chore: enable cache for build script in turbo.json

### DIFF
--- a/packages/ui-button/package.json
+++ b/packages/ui-button/package.json
@@ -7,7 +7,9 @@
     "dev": "tsup --watch",
     "build": "tsup",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "clean:dist": "pnpm -r --parallel exec rm -rf dist",
+    "clean:modules": "pnpm -r --parallel exec rm -rf node_modules"
   },
   "repository": {
     "type": "git",

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,8 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**/*"],
-      "inputs": ["packages/**/src/**"]
+      "inputs": ["packages/**/src/**"],
+      "cache": true
     },
     "dev": {
       "cache": false


### PR DESCRIPTION
## Description
This pull request enables caching for the build task in the `turbo.json` file, optimizing the build process by reducing the build times. Additionally, it introduces two new scripts.

- `clean:dist`: removes the `dist` folders from all packages
- `clean:modules`: removes the `node_modules` folders from all packages

## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->