### PR TITLE
chore: clean up `clean:dist` and `clean:modules`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "clean:dist": "pnpm -r --parallel exec rm -rf dist",
+    "clean:modules": "pnpm -r --parallel exec rm -rf node_modules"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-button/package.json
+++ b/packages/ui-button/package.json
@@ -7,9 +7,7 @@
     "dev": "tsup --watch",
     "build": "tsup",
     "format": "prettier --write .",
-    "format:check": "prettier --check .",
-    "clean:dist": "pnpm -r --parallel exec rm -rf dist",
-    "clean:modules": "pnpm -r --parallel exec rm -rf node_modules"
+    "format:check": "prettier --check ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
This pull request moves the `clean:dist` and `clean:modules` commands from the package.json in the `ui-button` directory to the root `package.json`. This change centralizes the commands, streamlining the build process across the project.


## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->