### PR TITLE
chore(release): bump version of @ui-button to 0.3.0

### DIFF
--- a/packages/ui-button/package.json
+++ b/packages/ui-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-button",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "A customizable button component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Description
This pull request publishes version `0.3.0` of the `@halvaradop/ui-button` package. It now supports the `asChild` property from the core package `@halvaradop/ui-core@0.2.0`

## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->