### PR TITLE
chore(release): bump version of @ui-core to 0.2.0

### DIFF
--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-core",
-  "version": "0.1.0-beta.13",
+  "version": "0.2.0",
   "description": "The core of the @halvaradop/ui library, providing customizable components with Tailwind CSS styling.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Description
This pull request published a new version `0.2.0`  of the `@halvaradop/ui-core` package, which introduce `asChild` propety. This feature allows users to change the default button HTML tag to any other valid tag, providing greater flexibility in how the button component is used.



## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->