### PR TITLE
chore: set `publishConfig` field in package.json

### DIFF
--- a/packages/ui-button/package.json
+++ b/packages/ui-button/package.json
@@ -13,6 +13,10 @@
     "type": "git",
     "url": "git+https://github.com/halvaradop/ui.git"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/@halvaradop/ui-button"
+  },
   "keywords": [
     "button",
     "react",

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -13,6 +13,10 @@
     "type": "git",
     "url": "git+https://github.com/halvaradop/ui.git"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/@halvaradop/ui-core"
+  },
   "keywords": [
     "react",
     "component",


### PR DESCRIPTION
## Description
This pull request adds the `publishConfig` field to the package.json files for both `@halvaradop/ui-button` and `@halvaradop/ui- core` packages. This configuration simplifies the publishing process by setting the access level to public by default, eliminating the need to use the `--access public` flag during each publish.

## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->