### PR TITLE
chore: add new scripts `clean:build` and `clean:modules`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "description": "A comprehensive UI library for React, built with Tailwind CSS and CVA (Class Variance Authority). It provides reusable components and supports JSX syntax.",
   "scripts": {
     "dev": "turbo run dev --parallel",
-    "build": "turbo run build",
+    "build": "turbo run build --filter=*ui-core && turbo build",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "clean:dist": "pnpm -r --parallel exec rm -rf dist",
-    "clean:modules": "pnpm -r --parallel exec rm -rf node_modules"
+    "clean:build": "turbo run clean:build --parallel",
+    "clean:modules": "turbo run clean:modules --parallel"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-button/package.json
+++ b/packages/ui-button/package.json
@@ -7,7 +7,9 @@
     "dev": "tsup --watch",
     "build": "tsup",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "clean:build": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -7,7 +7,9 @@
     "dev": "tsup --watch",
     "build": "tsup",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "clean:build": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-form/package.json
+++ b/packages/ui-form/package.json
@@ -8,7 +8,9 @@
     "dev": "tsup --watch",
     "build": "tsup",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "clean:build": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-input/package.json
+++ b/packages/ui-input/package.json
@@ -8,7 +8,9 @@
     "dev": "tsup --watch",
     "build": "tsup",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "clean:build": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-label/package.json
+++ b/packages/ui-label/package.json
@@ -8,7 +8,9 @@
     "dev": "tsup --watch",
     "build": "tsup",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "clean:build": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-template/package.json
+++ b/packages/ui-template/package.json
@@ -8,7 +8,9 @@
     "dev": "tsup --watch",
     "build": "tsup",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "clean:build": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules"
   },
   "repository": {
     "type": "git",

--- a/turbo.json
+++ b/turbo.json
@@ -4,11 +4,18 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**/*"],
-      "inputs": ["packages/**/src/**"],
+      "outputs": ["dist"],
+      "inputs": ["src"],
       "cache": true
     },
     "dev": {
+      "dependsOn": ["^dev"],
+      "cache": false
+    },
+    "clean:build": {
+      "cache": false
+    },
+    "clean:modules": {
       "cache": false
     }
   },


### PR DESCRIPTION
## Description
This pull request adds two new scripts: `clean:build` and `clean:modules`. These scripts are designed to remove the build files and the `node_modules` folder, ensuring that the code runs cleanly and avoiding potential bugs. Key changes include:

- Added `clean:build` script to delete generated build files.
- Added `clean:modules` script to remove the `node_modules` folder across all packages.

> [!TIP]
I've noticed that removing the `run` word in `dev` and `build` scripts triggers strange behavior, so we should keep an eye on Turborepo for potential issues.


## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->