### PR TITLE
fix: update depedencies in packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "homepage": "https://github.com/halvaradop/ui#readme",
   "devDependencies": {
     "@chromatic-com/storybook": "1.9.0",
-    "@halvaradop/ts-utility-types": "^0.10.0",
     "@storybook/addon-essentials": "^8.3.1",
     "@storybook/addon-interactions": "^8.3.1",
     "@storybook/addon-links": "^8.3.1",
@@ -56,7 +55,6 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react-swc": "^3.7.0",
     "autoprefixer": "^10.4.20",
-    "class-variance-authority": "^0.7.0",
     "postcss": "^8.4.45",
     "prettier": "^3.3.3",
     "react": "^18.3.1",

--- a/packages/ui-button/package.json
+++ b/packages/ui-button/package.json
@@ -44,7 +44,9 @@
       "require": "./dist/index.cjs"
     }
   },
-  "devDependencies": {
-    "@halvaradop/ui-core": "workspace:*"
+  "dependencies": {
+    "@halvaradop/ui-core": "workspace:*",
+    "class-variance-authority": "0.7.0",
+    "@halvaradop/ts-utility-types": "0.11.1"
   }
 }

--- a/packages/ui-dialog/package.json
+++ b/packages/ui-dialog/package.json
@@ -45,7 +45,9 @@
       "require": "./dist/index.cjs"
     }
   },
-  "devDependencies": {
-    "@halvaradop/ui-core": "workspace:*"
+  "dependencies": {
+    "@halvaradop/ui-core": "workspace:*",
+    "class-variance-authority": "0.7.0",
+    "@halvaradop/ts-utility-types": "0.11.1"
   }
 }

--- a/packages/ui-form/package.json
+++ b/packages/ui-form/package.json
@@ -45,7 +45,9 @@
       "require": "./dist/index.cjs"
     }
   },
-  "devDependencies": {
-    "@halvaradop/ui-core": "workspace:*"
+  "dependencies": {
+    "@halvaradop/ui-core": "workspace:*",
+    "class-variance-authority": "0.7.0",
+    "@halvaradop/ts-utility-types": "0.11.1"
   }
 }

--- a/packages/ui-input/package.json
+++ b/packages/ui-input/package.json
@@ -45,7 +45,9 @@
       "require": "./dist/index.cjs"
     }
   },
-  "devDependencies": {
-    "@halvaradop/ui-core": "workspace:*"
+  "dependencies": {
+    "@halvaradop/ui-core": "workspace:*",
+    "class-variance-authority": "0.7.0",
+    "@halvaradop/ts-utility-types": "0.11.1"
   }
 }

--- a/packages/ui-label/package.json
+++ b/packages/ui-label/package.json
@@ -45,7 +45,9 @@
       "require": "./dist/index.cjs"
     }
   },
-  "devDependencies": {
-    "@halvaradop/ui-core": "workspace:*"
+  "dependencies": {
+    "@halvaradop/ui-core": "workspace:*",
+    "class-variance-authority": "0.7.0",
+    "@halvaradop/ts-utility-types": "0.11.1"
   }
 }

--- a/packages/ui-template/package.json
+++ b/packages/ui-template/package.json
@@ -40,7 +40,9 @@
       "require": "./dist/index.cjs"
     }
   },
-  "devDependencies": {
-    "@halvaradop/ui-core": "workspace:*"
+  "dependencies": {
+    "@halvaradop/ui-core": "workspace:*",
+    "class-variance-authority": "0.7.0",
+    "@halvaradop/ts-utility-types": "0.11.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@chromatic-com/storybook':
         specifier: 1.9.0
         version: 1.9.0(react@18.3.1)
-      '@halvaradop/ts-utility-types':
-        specifier: ^0.10.0
-        version: 0.10.0
       '@storybook/addon-essentials':
         specifier: ^8.3.1
         version: 8.3.5(storybook@8.3.5)
@@ -56,9 +53,6 @@ importers:
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.47)
-      class-variance-authority:
-        specifier: ^0.7.0
-        version: 0.7.0
       postcss:
         specifier: ^8.4.45
         version: 8.4.47
@@ -115,10 +109,16 @@ importers:
         version: link:../ui-core
 
   packages/ui-input:
-    devDependencies:
+    dependencies:
+      '@halvaradop/ts-utility-types':
+        specifier: 0.11.1
+        version: 0.11.1
       '@halvaradop/ui-core':
         specifier: workspace:*
         version: link:../ui-core
+      class-variance-authority:
+        specifier: 0.7.0
+        version: 0.7.0
 
   packages/ui-label:
     devDependencies:
@@ -509,8 +509,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@halvaradop/ts-utility-types@0.10.0':
-    resolution: {integrity: sha512-U0j+zJJYC4d81JRQH57rvvjgVgArHkfPA3MA6qCHNX8aD1O+Pn6ZCYekBICz6wpzkJDnE5lrfWDnkd4G3/63RA==}
+  '@halvaradop/ts-utility-types@0.11.1':
+    resolution: {integrity: sha512-7t86TIg5cKxPweNMR6olMtZkeTJ6uoXN+hjTu+A9t1nvWh5bS0LtWO3yjOZ1hobjcgH+uy6gM7ApoIkpx/6BeA==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2873,7 +2873,7 @@ snapshots:
   '@esbuild/win32-x64@0.23.1':
     optional: true
 
-  '@halvaradop/ts-utility-types@0.10.0': {}
+  '@halvaradop/ts-utility-types@0.11.1': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,10 +85,16 @@ importers:
         version: 5.4.8(@types/node@22.7.4)
 
   packages/ui-button:
-    devDependencies:
+    dependencies:
+      '@halvaradop/ts-utility-types':
+        specifier: 0.11.1
+        version: 0.11.1
       '@halvaradop/ui-core':
         specifier: workspace:*
         version: link:../ui-core
+      class-variance-authority:
+        specifier: 0.7.0
+        version: 0.7.0
 
   packages/ui-core:
     devDependencies:
@@ -97,16 +103,28 @@ importers:
         version: 2.5.3
 
   packages/ui-dialog:
-    devDependencies:
+    dependencies:
+      '@halvaradop/ts-utility-types':
+        specifier: 0.11.1
+        version: 0.11.1
       '@halvaradop/ui-core':
         specifier: workspace:*
         version: link:../ui-core
+      class-variance-authority:
+        specifier: 0.7.0
+        version: 0.7.0
 
   packages/ui-form:
-    devDependencies:
+    dependencies:
+      '@halvaradop/ts-utility-types':
+        specifier: 0.11.1
+        version: 0.11.1
       '@halvaradop/ui-core':
         specifier: workspace:*
         version: link:../ui-core
+      class-variance-authority:
+        specifier: 0.7.0
+        version: 0.7.0
 
   packages/ui-input:
     dependencies:
@@ -121,16 +139,28 @@ importers:
         version: 0.7.0
 
   packages/ui-label:
-    devDependencies:
+    dependencies:
+      '@halvaradop/ts-utility-types':
+        specifier: 0.11.1
+        version: 0.11.1
       '@halvaradop/ui-core':
         specifier: workspace:*
         version: link:../ui-core
+      class-variance-authority:
+        specifier: 0.7.0
+        version: 0.7.0
 
   packages/ui-template:
-    devDependencies:
+    dependencies:
+      '@halvaradop/ts-utility-types':
+        specifier: 0.11.1
+        version: 0.11.1
       '@halvaradop/ui-core':
         specifier: workspace:*
         version: link:../ui-core
+      class-variance-authority:
+        specifier: 0.7.0
+        version: 0.7.0
 
 packages:
 


### PR DESCRIPTION
## Description
This pull request updates key dependencies in the packages by moving `halvaradop/ui-core`, `halvaradop/ts-utility-types`, and `class-variance-authority` from `devDependencies` to `dependencies`. These packages are essential for building and deploying the UI components effectively. 

### Key Changes:
- Move `halvaradop/ui-core` to `dependencies`
- Move `halvaradop/ts-utility-types` to `dependencies`
- Move `class-variance-authority` to `dependencies`

## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->