### PR TITLE
chore: add `clean` script in `package.json` of the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format:check": "prettier --check .",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
+    "clean": "turbo run clean --parallel",
     "clean:build": "turbo run clean:build --parallel",
     "clean:modules": "turbo run clean:modules --parallel"
   },

--- a/packages/ui-button/package.json
+++ b/packages/ui-button/package.json
@@ -8,6 +8,7 @@
     "build": "tsup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "clean": "pnpm clean:build && pnpm clean:modules",
     "clean:build": "rm -rf dist",
     "clean:modules": "rm -rf node_modules"
   },

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -8,6 +8,7 @@
     "build": "tsup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "clean": "pnpm clean:build && pnpm clean:modules",
     "clean:build": "rm -rf dist",
     "clean:modules": "rm -rf node_modules"
   },

--- a/packages/ui-dialog/package.json
+++ b/packages/ui-dialog/package.json
@@ -9,6 +9,7 @@
     "build": "tsup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "clean": "pnpm clean:build && pnpm clean:modules",
     "clean:build": "rm -rf dist",
     "clean:modules": "rm -rf node_modules"
   },

--- a/packages/ui-form/package.json
+++ b/packages/ui-form/package.json
@@ -9,6 +9,7 @@
     "build": "tsup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "clean": "pnpm clean:build && pnpm clean:modules",
     "clean:build": "rm -rf dist",
     "clean:modules": "rm -rf node_modules"
   },

--- a/packages/ui-input/package.json
+++ b/packages/ui-input/package.json
@@ -9,6 +9,7 @@
     "build": "tsup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "clean": "pnpm clean:build && pnpm clean:modules",
     "clean:build": "rm -rf dist",
     "clean:modules": "rm -rf node_modules"
   },

--- a/packages/ui-label/package.json
+++ b/packages/ui-label/package.json
@@ -9,6 +9,7 @@
     "build": "tsup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "clean": "pnpm clean:build && pnpm clean:modules",
     "clean:build": "rm -rf dist",
     "clean:modules": "rm -rf node_modules"
   },

--- a/packages/ui-label/src/index.tsx
+++ b/packages/ui-label/src/index.tsx
@@ -6,7 +6,7 @@ export const labelVariants = cva("font-medium relative leading-none", {
     variants: {
         variant: {
             base: "text-slate-700",
-            error: "hidden text-rose-400 absolute top-0 peer-usvalid:block peer-usvalid-empty:hidden",
+            error: "hidden text-rose-400 absolute top-0 peer-usinvalid:block peer-usinvalid-empty:hidden",
             flex: "flex flex-col items-start",
         },
         size: {

--- a/packages/ui-submit/package.json
+++ b/packages/ui-submit/package.json
@@ -9,6 +9,7 @@
     "build": "tsup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "clean": "pnpm clean:build && pnpm clean:modules",
     "clean:build": "rm -rf dist",
     "clean:modules": "rm -rf node_modules"
   },

--- a/packages/ui-template/package.json
+++ b/packages/ui-template/package.json
@@ -9,6 +9,7 @@
     "build": "tsup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "clean": "pnpm clean:build && pnpm clean:modules",
     "clean:build": "rm -rf dist",
     "clean:modules": "rm -rf node_modules"
   },

--- a/packages/ui-template/src/index.tsx
+++ b/packages/ui-template/src/index.tsx
@@ -1,6 +1,5 @@
 import { ComponentProps } from "react"
-import type { ArgsFunction } from "@halvaradop/ts-utility-types"
-import { merge, cva, type VariantProps } from "@halvaradop/ui-core"
+import { merge, cva, type VariantProps, type ArgsFunction } from "@halvaradop/ui-core"
 
 export type IndexProps<T extends ArgsFunction> = VariantProps<T> & ComponentProps<"div">
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,8 +19,8 @@ const config: Config = {
             addVariant("usinvalid", "&:user-invalid")
             addVariant("usvalid", "&:user-valid")
             addVariant("input-empty", "&:is(:usinvalid:placeholder-shown, :placeholder-shown)")
-            addVariant("peer-usvalid", ".peer:user-invalid ~ &")
-            addVariant("peer-usvalid-empty", ".peer:user-invalid:placeholder-shown ~ &")
+            addVariant("peer-usinvalid", ".peer:user-invalid ~ &")
+            addVariant("peer-usinvalid-empty", ".peer:user-invalid:placeholder-shown ~ &")
         }),
     ],
 }

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,10 @@
       "dependsOn": ["^dev"],
       "cache": false
     },
+    "clean": {
+      "cache": false,
+      "inputs": ["dist", "node_modules"]
+    },
     "clean:build": {
       "cache": false
     },


### PR DESCRIPTION
## Description
This pull request introduces the `clean` script in the `package.json` of the packages within the monorepo. This new script executes `clean:build` and `clean:modules` scripts to remove all files and folders for production. This command is useful to maintain clean code and verify it without the dependencies and dist folders.

## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
