### PR TITLE
feat: add `Submit` component

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "description": "A comprehensive UI library for React, built with Tailwind CSS and CVA (Class Variance Authority). It provides reusable components and supports JSX syntax.",
   "scripts": {
     "dev": "turbo run dev --parallel",
-    "build": "turbo run build --filter=*core --filter=!*core",
+    "build": "pnpm build:core && turbo build --parallel --filter=!*core --filter=!*template",
+    "build:core": "turbo run build --filter=*core",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "storybook": "storybook dev -p 6006",

--- a/packages/ui-submit/package.json
+++ b/packages/ui-submit/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@halvaradop/ui-template",
+  "name": "@halvaradop/ui-submit",
   "version": "0.1.0",
   "private": false,
-  "description": "A customizable {_} component for @halvaradop/ui library with Tailwind CSS styling.",
+  "description": "A customizable submit component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",
   "scripts": {
     "dev": "tsup --watch",

--- a/packages/ui-submit/src/index.tsx
+++ b/packages/ui-submit/src/index.tsx
@@ -1,0 +1,40 @@
+"use client"
+import { ComponentProps } from "react"
+import { useFormStatus } from "react-dom"
+import { type ArgsFunction, type VariantProps, cva } from "@halvaradop/ui-core"
+
+export type SubmitProps<T extends ArgsFunction> = Omit<ComponentProps<"input">, "type" | "size"> & VariantProps<T> & { pending?: string }
+
+export const submitVariants = cva("font-medium border focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-2 disabled:hover:cursor-progress", {
+    variants: {
+        variant: {
+            base: "text-white border-black bg-black ring-black disabled:bg-opacity-90",
+            inverted: "text-black border-white bg-white ring-white ring-offset-black disabled:border-black disabled:bg-opacity-90",
+        },
+        size: {
+            sm: "h-9 px-3 text-sm rounded",
+            base: "h-10 px-4 text-base rounded-md",
+            md: "h-10 px-5 text-base rounded-md",
+            lg: "h-11 px-6 text-lg rounded-lg",
+        },
+        fullWidth: {
+            true: "w-full",
+            false: "w-fit",
+        },
+        fullRounded: {
+            true: "rounded-full",
+        },
+    },
+    defaultVariants: {
+        variant: "base",
+        size: "base",
+        fullWidth: false,
+        fullRounded: false,
+    },
+})
+
+export const Submit = ({ className, variant, size, fullWidth, fullRounded, value = "Submit", pending = "Submitting...", ref, ...props }: SubmitProps<typeof submitVariants>) => {
+    const { pending: status } = useFormStatus()
+    const message = status ? pending : value
+    return <input className={submitVariants({ className, variant, size, fullWidth, fullRounded })} type="submit" value={message} disabled={status} aria-disabled={status} ref={ref} {...props} />
+}

--- a/packages/ui-submit/src/submit.stories.tsx
+++ b/packages/ui-submit/src/submit.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { Submit } from "./index.js"
+
+const meta: Meta = {
+    title: "ui-submit",
+    tags: ["autodocs"],
+    component: Submit,
+    parameters: {
+        layout: "centered",
+    },
+} satisfies Meta<typeof Submit>
+
+type Story = StoryObj<typeof meta>
+
+const Template = ({ className, ...props }: Parameters<typeof Submit>[0]) => {
+    const action = async () => await new Promise((resolve) => setTimeout(resolve, 2000))
+
+    return (
+        <form className={className} action={action}>
+            <Submit {...props} />
+        </form>
+    )
+}
+
+export const Base: Story = {
+    render: () => <Template />,
+}
+
+export const Inverted: Story = {
+    render: () => <Template className="p-10 bg-black" variant="inverted" />,
+}
+
+export const Small: Story = {
+    render: () => <Template size="sm" />,
+}
+
+export const Medium: Story = {
+    render: () => <Template size="md" />,
+}
+
+export const Large: Story = {
+    render: () => <Template size="lg" />,
+}
+
+export default meta

--- a/packages/ui-submit/tsconfig.json
+++ b/packages/ui-submit/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@halvaradop/ui-core/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/ui-submit/tsup.config.ts
+++ b/packages/ui-submit/tsup.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from "tsup"
+import { tsupConfig } from "@halvaradop/ui-core/tsup.config.base"
+
+export default defineConfig(tsupConfig)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,11 +130,14 @@ importers:
         specifier: workspace:*
         version: link:../ui-core
 
+  packages/ui-submit:
+    dependencies:
+      '@halvaradop/ui-core':
+        specifier: workspace:*
+        version: link:../ui-core
+
   packages/ui-template:
     dependencies:
-      '@halvaradop/ts-utility-types':
-        specifier: 0.11.1
-        version: 0.11.1
       '@halvaradop/ui-core':
         specifier: workspace:*
         version: link:../ui-core
@@ -504,9 +507,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@halvaradop/ts-utility-types@0.11.1':
-    resolution: {integrity: sha512-7t86TIg5cKxPweNMR6olMtZkeTJ6uoXN+hjTu+A9t1nvWh5bS0LtWO3yjOZ1hobjcgH+uy6gM7ApoIkpx/6BeA==}
 
   '@halvaradop/ts-utility-types@0.15.0':
     resolution: {integrity: sha512-e3AC/OnD6xn27ukp86UtdQlQKd82HLVSlNgk5JS6cKWWHWH5eTC860M6qm1RAILuIdL/a5r4BCdFxPgJAnY5qw==}
@@ -2439,8 +2439,6 @@ snapshots:
 
   '@esbuild/win32-x64@0.24.0':
     optional: true
-
-  '@halvaradop/ts-utility-types@0.11.1': {}
 
   '@halvaradop/ts-utility-types@0.15.0': {}
 


### PR DESCRIPTION
## Description

This pull request introduces a new component called `Submit`, which uses the `useFormState` hook from `react-dom` to determine the status of the action or submit event. This is useful to avoid duplicate requests by disabling the component to prevent the user from clicking again until the state is `success` or `finished`.


## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
