### PR TITLE
fix: resolve issue in `cva` types to build packages

### DIFF
--- a/packages/ui-button/package.json
+++ b/packages/ui-button/package.json
@@ -46,6 +46,7 @@
     }
   },
   "dependencies": {
-    "@halvaradop/ui-core": "workspace:*"
+    "@halvaradop/ui-core": "workspace:*",
+    "class-variance-authority": "0.7.0"
   }
 }

--- a/packages/ui-button/src/index.tsx
+++ b/packages/ui-button/src/index.tsx
@@ -1,5 +1,5 @@
-import { merge, Slot, type SlotProps, ArgsFunction, cva, VariantProps } from "@halvaradop/ui-core"
-//import { cva, type VariantProps } from "class-variance-authority"
+import { merge, Slot, type SlotProps, ArgsFunction } from "@halvaradop/ui-core"
+import { cva, type VariantProps } from "class-variance-authority"
 
 export type ButtonProps<T extends ArgsFunction> = SlotProps<"button"> & VariantProps<T>
 

--- a/packages/ui-button/src/index.tsx
+++ b/packages/ui-button/src/index.tsx
@@ -1,4 +1,5 @@
-import { cva, merge, Slot, type SlotProps, type VariantProps, ArgsFunction } from "@halvaradop/ui-core"
+import { merge, Slot, type SlotProps, ArgsFunction, cva, VariantProps } from "@halvaradop/ui-core"
+//import { cva, type VariantProps } from "class-variance-authority"
 
 export type ButtonProps<T extends ArgsFunction> = SlotProps<"button"> & VariantProps<T>
 

--- a/packages/ui-checkbox/package.json
+++ b/packages/ui-checkbox/package.json
@@ -46,6 +46,7 @@
     }
   },
   "dependencies": {
-    "@halvaradop/ui-core": "workspace:*"
+    "@halvaradop/ui-core": "workspace:*",
+    "class-variance-authority": "0.7.0"
   }
 }

--- a/packages/ui-checkbox/src/index.tsx
+++ b/packages/ui-checkbox/src/index.tsx
@@ -1,5 +1,6 @@
 import { ComponentProps } from "react"
-import { merge, cva, type VariantProps, type ArgsFunction } from "@halvaradop/ui-core"
+import { merge, type ArgsFunction } from "@halvaradop/ui-core"
+import { cva, type VariantProps } from "class-variance-authority"
 
 export type CheckboxProps<T extends ArgsFunction> = VariantProps<T> & Omit<ComponentProps<"input">, "type" | "size">
 
@@ -42,13 +43,15 @@ export const checkboxVariants = cva("appearance-none border border-gray-400 focu
     },
 })
 
-export const Checkbox = ({ className, size, color, name }: CheckboxProps<typeof checkboxVariants>) => {
+export const Checkbox = ({ className, size, color, name, ref }: CheckboxProps<typeof checkboxVariants>) => {
     return (
         <label className="flex items-center justify-center relative" htmlFor={name}>
-            <input className={merge(checkboxVariants({ className, size, color }), "peer")} type="checkbox" name={name} />
+            <input className={merge(checkboxVariants({ className, size, color }), "peer")} type="checkbox" name={name} ref={ref} />
             <svg className={internalVariants({ size })} xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" fill="#fff">
                 <path d="M382-240 154-468l57-57 171 171 367-367 57 57-424 424Z" />
             </svg>
         </label>
     )
 }
+
+Checkbox.displayName = "Checkbox"

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -35,12 +35,6 @@
     "url": "https://github.com/halvaradop/ui/issues"
   },
   "homepage": "https://github.com/halvaradop/ui#readme",
-  "devDependencies": {
-    "@halvaradop/ts-utility-types": "0.15.0",
-    "class-variance-authority": "0.7.0",
-    "clsx": "^2.1.1",
-    "tailwind-merge": "^2.5.2"
-  },
   "files": [
     "dist"
   ],
@@ -65,5 +59,12 @@
     "./utility-types": {
       "types": "./dist/utility-types.d.ts"
     }
+  },
+  "dependencies": {
+    "tailwind-merge": "^2.5.2"
+  },
+  "devDependencies": {
+    "@halvaradop/ts-utility-types": "0.15.0",
+    "clsx": "^2.1.1"
   }
 }

--- a/packages/ui-core/src/index.ts
+++ b/packages/ui-core/src/index.ts
@@ -1,5 +1,4 @@
-export * from "./utils.js"
 export * from "./tsup.config.base.js"
 export * from "./slot.js"
-export * from "class-variance-authority"
+export * from "./utils.js"
 export type * from "@halvaradop/ts-utility-types"

--- a/packages/ui-core/src/utils.ts
+++ b/packages/ui-core/src/utils.ts
@@ -1,5 +1,5 @@
 import { twMerge } from "tailwind-merge"
-import clsx, { ClassValue } from "clsx"
+import { clsx, ClassValue } from "clsx"
 
 /**
  * Merge multiple classes into a single class string. It prioritizes the

--- a/packages/ui-dialog/package.json
+++ b/packages/ui-dialog/package.json
@@ -47,6 +47,7 @@
     }
   },
   "dependencies": {
-    "@halvaradop/ui-core": "workspace:*"
+    "@halvaradop/ui-core": "workspace:*",
+    "class-variance-authority": "0.7.0"
   }
 }

--- a/packages/ui-dialog/src/index.tsx
+++ b/packages/ui-dialog/src/index.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps } from "react"
-import { merge, cva, type VariantProps, type ArgsFunction } from "@halvaradop/ui-core"
+import { merge, type ArgsFunction } from "@halvaradop/ui-core"
+import { cva, type VariantProps } from "class-variance-authority"
 
 export type DialogProps<T extends ArgsFunction> = ComponentProps<"dialog"> & VariantProps<T>
 
@@ -31,4 +32,4 @@ export const Modal = ({ className, children, ref, ...props }: DialogProps<typeof
     )
 }
 
-Modal.displayName = "dialog"
+Modal.displayName = "Dialog"

--- a/packages/ui-form/package.json
+++ b/packages/ui-form/package.json
@@ -47,6 +47,7 @@
     }
   },
   "dependencies": {
-    "@halvaradop/ui-core": "workspace:*"
+    "@halvaradop/ui-core": "workspace:*",
+    "class-variance-authority": "0.7.0"
   }
 }

--- a/packages/ui-form/src/index.tsx
+++ b/packages/ui-form/src/index.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps } from "react"
-import { merge, cva, type VariantProps, type ArgsFunction } from "@halvaradop/ui-core"
+import { merge, type ArgsFunction } from "@halvaradop/ui-core"
+import { cva, type VariantProps } from "class-variance-authority"
 
 export type FormProps<T extends ArgsFunction> = VariantProps<T> & ComponentProps<"form">
 
@@ -32,4 +33,4 @@ export const Form = ({ className, variant, size, children, ref, ...props }: Form
     )
 }
 
-Form.displayName = "form"
+Form.displayName = "Form"

--- a/packages/ui-input/package.json
+++ b/packages/ui-input/package.json
@@ -47,6 +47,7 @@
     }
   },
   "dependencies": {
-    "@halvaradop/ui-core": "workspace:*"
+    "@halvaradop/ui-core": "workspace:*",
+    "class-variance-authority": "0.7.0"
   }
 }

--- a/packages/ui-input/src/index.tsx
+++ b/packages/ui-input/src/index.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps } from "react"
-import { merge, cva, type VariantProps, type ArgsFunction } from "@halvaradop/ui-core"
+import { merge, type ArgsFunction } from "@halvaradop/ui-core"
+import { cva, type VariantProps } from "class-variance-authority"
 
 export type InputProps<T extends ArgsFunction> = Omit<ComponentProps<"input">, "size"> & VariantProps<T>
 
@@ -38,4 +39,4 @@ export const Input = ({ className, variant, size, fullWidth, fullRounded, type, 
     return <input className={merge(inputVariants({ className, variant, size, fullWidth, fullRounded }))} type={type} ref={ref} {...props} />
 }
 
-Input.displayName = "input"
+Input.displayName = "Input"

--- a/packages/ui-label/package.json
+++ b/packages/ui-label/package.json
@@ -47,6 +47,7 @@
     }
   },
   "dependencies": {
-    "@halvaradop/ui-core": "workspace:*"
+    "@halvaradop/ui-core": "workspace:*",
+    "class-variance-authority": "0.7.0"
   }
 }

--- a/packages/ui-label/src/index.tsx
+++ b/packages/ui-label/src/index.tsx
@@ -1,4 +1,5 @@
-import { merge, cva, Slot, type SlotProps, type VariantProps, type ArgsFunction } from "@halvaradop/ui-core"
+import { merge, Slot, type SlotProps, type ArgsFunction } from "@halvaradop/ui-core"
+import { cva, type VariantProps } from "class-variance-authority"
 
 export type LabelProps<T extends ArgsFunction> = SlotProps<"label"> & VariantProps<T>
 
@@ -30,4 +31,4 @@ export const Label = ({ className, variant, size, children, asChild, ref, ...pro
     )
 }
 
-Label.displayName = "label"
+Label.displayName = "Label"

--- a/packages/ui-submit/package.json
+++ b/packages/ui-submit/package.json
@@ -46,6 +46,7 @@
     }
   },
   "dependencies": {
-    "@halvaradop/ui-core": "workspace:*"
+    "@halvaradop/ui-core": "workspace:*",
+    "class-variance-authority": "0.7.0"
   }
 }

--- a/packages/ui-submit/src/index.tsx
+++ b/packages/ui-submit/src/index.tsx
@@ -1,15 +1,15 @@
 "use client"
 import { ComponentProps } from "react"
-import { useFormStatus } from "react-dom"
-import { type ArgsFunction, type VariantProps, cva } from "@halvaradop/ui-core"
+import { ArgsFunction, merge } from "@halvaradop/ui-core"
+import { cva, VariantProps } from "class-variance-authority"
 
-export type SubmitProps<T extends ArgsFunction> = Omit<ComponentProps<"input">, "type" | "size"> & VariantProps<T> & { pending?: string }
+export type SubmitProps<T extends ArgsFunction> = VariantProps<T> & Omit<ComponentProps<"input">, "type" | "size"> & { pending?: string }
 
 export const submitVariants = cva("font-medium border focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-2 disabled:hover:cursor-progress", {
     variants: {
         variant: {
             base: "text-white border-black bg-black ring-black disabled:bg-opacity-90",
-            inverted: "text-black border-white bg-white ring-white ring-offset-black disabled:border-black disabled:bg-opacity-90",
+            inverted: " inverted text-black border-white bg-white ring-white ring-offset-black disabled:border-black disabled:bg-opacity-90",
         },
         size: {
             sm: "h-9 px-3 text-sm rounded",
@@ -33,8 +33,8 @@ export const submitVariants = cva("font-medium border focus-within:outline-none 
     },
 })
 
-export const Submit = ({ className, variant, size, fullWidth, fullRounded, value = "Submit", pending = "Submitting...", ref, ...props }: SubmitProps<typeof submitVariants>) => {
-    const { pending: status } = useFormStatus()
+export const Submit = ({ className, value = "Submit", pending = "Submitting..." }: SubmitProps<typeof submitVariants>) => {
+    const { pending: status } = { pending: false }
     const message = status ? pending : value
-    return <input className={submitVariants({ className, variant, size, fullWidth, fullRounded })} type="submit" value={message} disabled={status} aria-disabled={status} ref={ref} {...props} />
+    return <input className={merge(submitVariants({ className }))} type="submit" value={message} disabled={status} aria-disabled={status} />
 }

--- a/packages/ui-submit/src/index.tsx
+++ b/packages/ui-submit/src/index.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { ComponentProps } from "react"
-import { ArgsFunction, merge } from "@halvaradop/ui-core"
+import { useFormStatus } from "react-dom"
+import { type ArgsFunction, merge } from "@halvaradop/ui-core"
 import { cva, VariantProps } from "class-variance-authority"
 
 export type SubmitProps<T extends ArgsFunction> = VariantProps<T> & Omit<ComponentProps<"input">, "type" | "size"> & { pending?: string }
@@ -9,7 +10,7 @@ export const submitVariants = cva("font-medium border focus-within:outline-none 
     variants: {
         variant: {
             base: "text-white border-black bg-black ring-black disabled:bg-opacity-90",
-            inverted: " inverted text-black border-white bg-white ring-white ring-offset-black disabled:border-black disabled:bg-opacity-90",
+            inverted: "text-black border-white bg-white ring-white ring-offset-black disabled:border-black disabled:bg-opacity-90",
         },
         size: {
             sm: "h-9 px-3 text-sm rounded",
@@ -33,8 +34,10 @@ export const submitVariants = cva("font-medium border focus-within:outline-none 
     },
 })
 
-export const Submit = ({ className, value = "Submit", pending = "Submitting..." }: SubmitProps<typeof submitVariants>) => {
-    const { pending: status } = { pending: false }
+export const Submit = ({ className, variant, size, fullWidth, fullRounded, value = "Submit", pending = "Submitting...", ref, ...props }: SubmitProps<typeof submitVariants>) => {
+    const { pending: status } = useFormStatus()
     const message = status ? pending : value
-    return <input className={merge(submitVariants({ className }))} type="submit" value={message} disabled={status} aria-disabled={status} />
+    return <input className={merge(submitVariants({ className, variant, size, fullWidth, fullRounded }))} type="submit" value={message} disabled={status} aria-disabled={status} ref={ref} {...props} />
 }
+
+Submit.displayName = "Input"

--- a/packages/ui-template/package.json
+++ b/packages/ui-template/package.json
@@ -42,6 +42,7 @@
     }
   },
   "dependencies": {
-    "@halvaradop/ui-core": "workspace:*"
+    "@halvaradop/ui-core": "workspace:*",
+    "class-variance-authority": "0.7.0"
   }
 }

--- a/packages/ui-template/src/index.tsx
+++ b/packages/ui-template/src/index.tsx
@@ -1,5 +1,6 @@
 import { ComponentProps } from "react"
-import { merge, cva, type VariantProps, type ArgsFunction } from "@halvaradop/ui-core"
+import { merge, type ArgsFunction } from "@halvaradop/ui-core"
+import { cva, type VariantProps } from "class-variance-authority"
 
 export type IndexProps<T extends ArgsFunction> = VariantProps<T> & ComponentProps<"div">
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,63 +90,85 @@ importers:
       '@halvaradop/ui-core':
         specifier: workspace:*
         version: link:../ui-core
+      class-variance-authority:
+        specifier: 0.7.0
+        version: 0.7.0
 
   packages/ui-checkbox:
     dependencies:
       '@halvaradop/ui-core':
         specifier: workspace:*
         version: link:../ui-core
+      class-variance-authority:
+        specifier: 0.7.0
+        version: 0.7.0
 
   packages/ui-core:
+    dependencies:
+      tailwind-merge:
+        specifier: ^2.5.2
+        version: 2.5.3
     devDependencies:
       '@halvaradop/ts-utility-types':
         specifier: 0.15.0
         version: 0.15.0
-      class-variance-authority:
-        specifier: 0.7.0
-        version: 0.7.0
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      tailwind-merge:
-        specifier: ^2.5.2
-        version: 2.5.3
 
   packages/ui-dialog:
     dependencies:
       '@halvaradop/ui-core':
         specifier: workspace:*
         version: link:../ui-core
+      class-variance-authority:
+        specifier: 0.7.0
+        version: 0.7.0
 
   packages/ui-form:
     dependencies:
       '@halvaradop/ui-core':
         specifier: workspace:*
         version: link:../ui-core
+      class-variance-authority:
+        specifier: 0.7.0
+        version: 0.7.0
 
   packages/ui-input:
     dependencies:
       '@halvaradop/ui-core':
         specifier: workspace:*
         version: link:../ui-core
+      class-variance-authority:
+        specifier: 0.7.0
+        version: 0.7.0
 
   packages/ui-label:
     dependencies:
       '@halvaradop/ui-core':
         specifier: workspace:*
         version: link:../ui-core
+      class-variance-authority:
+        specifier: 0.7.0
+        version: 0.7.0
 
   packages/ui-submit:
     dependencies:
       '@halvaradop/ui-core':
         specifier: workspace:*
         version: link:../ui-core
+      class-variance-authority:
+        specifier: 0.7.0
+        version: 0.7.0
 
   packages/ui-template:
     dependencies:
       '@halvaradop/ui-core':
         specifier: workspace:*
         version: link:../ui-core
+      class-variance-authority:
+        specifier: 0.7.0
+        version: 0.7.0
 
 packages:
 


### PR DESCRIPTION
## Description

This pull request resolves the issues thrown by `CVA` when building the packages, which do not recognize the types re-exported from the `@halvaradop/ui-core` package. This package had `class-variance-authority` installed and re-exported to improve clarity for the components of the library. The following image illustrates the error encountered during compilation:

![image](https://github.com/user-attachments/assets/93ec533f-6766-4c4c-93a6-e2a2c9785280)

To resolve these errors, I removed the `class-variance-authority` package from `@halvaradop/ui-core` and installed this dependency in each component package to ensure proper functionality during the build process. Additionally, the `@halvaradop/ts-utility-types` and `clsx` dependencies were moved from `dependencies` to `devDependencies`.

Finally, I updated the `Submit` component, adding the `merge` function to combine the provided classes and updated some related code. It is important to note that this component is not stable due to its use of the `useFormStatus` hook from `react-dom`. The component currently throws an error when using this hook.

### Key Changes
- Removed `class-variance-authority` package from `@halvaradop/ui-core` and installed it in each component package
- Moved `@halvaradop/ts-utility-types` and `clsx` dependencies to `devDependencies`
- Updated `Submit` component to use the `merge` function and related code changes
- Highlighted the instability of the `Submit` component due to the `useFormStatus` hook



## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
