### PR TITLE
chore: downgrad `react` and `react-dom` dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,32 @@ yarn add @halvaradop/ui-component@beta
 pnpm add @halvaradop/ui-component@beta
 ```
 
+Import components and start building your application:
+
+```tsx
+import { Button } from "@halvaradop/ui-button"
+
+export default function App() {
+  return <Button variant="outline">Click Me</Button>
+}
+```
+
+Check the full list of components in the [packages directory](https://github.com/halvaradop/ui/tree/master/packages).
+
+## Styles
+
+To add styles from the library to any of the components in your project, you need to add the pattern `"./node_modules/@halvaradop/ui-*/**/*.{js,ts,jsx,tsx,mdx}"` within the `tailwind.config.ts` file. This will allow TailwindCSS to recognize the classes used in the library and apply the styles to the components.
+
+```ts
+import type { Config } from "tailwindcss"
+
+const config: Config = {
+  content: ["./node_modules/@halvaradop/ui-*/**/*.{js,ts,jsx,tsx,mdx}"],
+}
+
+export default config
+```
+
 ## Notes
 
 The beta version works, however, it may have minor changes or issues compared to the stable version. If you find a problem or issue, please report it in an [Issue](https://github.com/halvaradop/ui/issues) with the details.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,48 @@
 # @halvaradop/ui
 
-@halvaradop/ui is a library of accessible, reusable, and customizable UI components for web applications built with React and styled using TailwindCSS. It provides a set of pre-styled components designed to streamline and accelerate the development of user interfaces.
+This is a library of accessible, reusable, and customizable UI components for web applications built with React and styled using TailwindCSS. It provides a set of pre-styled components designed to streamline and accelerate the development of user interfaces.
+
+## Version Compatibility
+
+This library supports both `React 18` and `React 19`. Refer to the table below to select the appropriate version of the library based on your React version:
+
+| React version | Library version            |
+| ------------- | -------------------------- |
+| React 18      | Latest version ^x.y.z      |
+| React 19      | Beta version ^x.y.x-beta.n |
 
 ## Installation
 
-To install the available components, you can refer to the [packages](https://github.com/halvaradop/ui/tree/master/packages) and add the package name with the `@halvaradop` prefix. Then, run one of the following commands based on your package manager:
+To install the available components, you can refer to the [packages](https://github.com/halvaradop/ui/tree/master/packages) and add the package name with the `@halvaradop` prefix. Then, run one of the following commands based on your package manager and the React version you are using:
+
+### For React 18
+
+Install the stable version:
 
 ```bash
-npm i @halvaradop/ui-button
-yarn add @halvaradop/ui-button
-pnpm add @halvaradop/ui-button
+npm install @halvaradop/ui-component
+yarn add @halvaradop/ui-component
+pnpm add @halvaradop/ui-component
 ```
+
+### For React 19
+
+Install the beta version:
+
+```bash
+npm install @halvaradop/ui-component@beta
+yarn add @halvaradop/ui-component@beta
+pnpm add @halvaradop/ui-component@beta
+```
+
+## Notes
+
+The beta version works, however, it may have minor changes or issues compared to the stable version. If you find a problem or issue, please report it in an [Issue](https://github.com/halvaradop/ui/issues) with the details.
 
 ## Contributing
 
-Welcome to contribute to @halvaradop/ui library if you have an idea, find an issue or you have an amazing advices, please feel free to open an issue or create a pull request. We offer a guide on how to contribute to the project and the necessary steps to do so. Here's how you can contribute, Read our [Contribuing Guideline](https://github.com/halvaradop/.github/blob/master/.github/CONTRIBUTING.md).
+Welcome to contribute to `@halvaradop/ui library` if you have an idea, find an issue or you have an amazing advices, please feel free to open an issue or create a pull request. We offer a guide on how to contribute to the project and the necessary steps to do so. Here's how you can contribute, Read our [Contribuing Guideline](https://github.com/halvaradop/.github/blob/master/.github/CONTRIBUTING.md).
 
-# Code of conduct
+# Code Of Conduct
 
 Please be aware that this project has a code of conduct, and we expect all contributors to follow these guidelines in their interactions. For more information, please read our [Code of Conduct](https://github.com/halvaradop/.github/blob/master/.github/CODE_OF_CONDUCT.md).

--- a/package.json
+++ b/package.json
@@ -41,10 +41,6 @@
     "url": "https://github.com/halvaradop/ui/issues"
   },
   "homepage": "https://github.com/halvaradop/ui#readme",
-  "dependencies": {
-    "@types/react": "npm:types-react@rc",
-    "@types/react-dom": "npm:types-react-dom@rc"
-  },
   "devDependencies": {
     "@chromatic-com/storybook": "1.9.0",
     "@storybook/addon-essentials": "^8.4.5",
@@ -63,8 +59,8 @@
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.49",
     "prettier": "^3.4.1",
-    "react": "19.0.0-rc.1",
-    "react-dom": "19.0.0-rc.1",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
     "storybook": "^8.4.5",
     "tailwindcss": "^3.4.15",
     "tsup": "^8.3.5",
@@ -75,10 +71,6 @@
   "peerDependencies": {
     "react": ">=18",
     "react-dom": ">=18"
-  },
-  "overrides": {
-    "@types/react": "npm:types-react@rc",
-    "@types/react-dom": "npm:types-react-dom@rc"
   },
   "packageManager": "pnpm@9.0.0-rc.0",
   "engines": {

--- a/packages/ui-core/src/slot.ts
+++ b/packages/ui-core/src/slot.ts
@@ -2,8 +2,7 @@ import { type ReactNode, Children, isValidElement, cloneElement, ComponentProps 
 
 export const Slot = ({ children, ...props }: { children: React.ReactNode }) => {
     if (isValidElement(children)) {
-        const chilProps = children.props ?? {}
-        return cloneElement(children, { ...props, ...chilProps })
+        return cloneElement(children, { ...props, ...children.props })
     }
     if (Children.count(children) > 1) {
         Children.only(null)

--- a/packages/ui-submit/src/index.tsx
+++ b/packages/ui-submit/src/index.tsx
@@ -1,6 +1,5 @@
 "use client"
 import { ComponentProps } from "react"
-import { useFormStatus } from "react-dom"
 import { type ArgsFunction, type VariantProps, cva } from "@halvaradop/ui-core"
 
 export type SubmitProps<T extends ArgsFunction> = Omit<ComponentProps<"input">, "type" | "size"> & VariantProps<T> & { pending?: string }
@@ -33,8 +32,7 @@ export const submitVariants = cva("font-medium border focus-within:outline-none 
     },
 })
 
-export const Submit = ({ className, variant, size, fullWidth, fullRounded, value = "Submit", pending = "Submitting...", ref, ...props }: SubmitProps<typeof submitVariants>) => {
-    const { pending: status } = useFormStatus()
-    const message = status ? pending : value
-    return <input className={submitVariants({ className, variant, size, fullWidth, fullRounded })} type="submit" value={message} disabled={status} aria-disabled={status} ref={ref} {...props} />
+export const Submit = ({ className, variant, size, fullWidth, fullRounded, value = "Submit", pending = "Submitting...", disabled, ref, ...props }: SubmitProps<typeof submitVariants>) => {
+    const message = disabled ? pending : value
+    return <input className={submitVariants({ className, variant, size, fullWidth, fullRounded })} type="submit" value={message} disabled={disabled} aria-disabled={disabled} ref={ref} {...props} />
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,47 +7,46 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@types/react':
-        specifier: npm:types-react@rc
-        version: types-react@19.0.0-rc.1
-      '@types/react-dom':
-        specifier: npm:types-react-dom@rc
-        version: types-react-dom@19.0.0-rc.1
     devDependencies:
       '@chromatic-com/storybook':
         specifier: 1.9.0
-        version: 1.9.0(react@19.0.0-rc.1)
+        version: 1.9.0(react@18.3.1)
       '@storybook/addon-essentials':
         specifier: ^8.4.5
-        version: 8.4.5(storybook@8.4.5(prettier@3.4.1))(types-react@19.0.0-rc.1)
+        version: 8.4.5(@types/react@18.3.12)(storybook@8.4.5(prettier@3.4.1))
       '@storybook/addon-interactions':
         specifier: ^8.4.5
         version: 8.4.5(storybook@8.4.5(prettier@3.4.1))
       '@storybook/addon-links':
         specifier: ^8.4.5
-        version: 8.4.5(react@19.0.0-rc.1)(storybook@8.4.5(prettier@3.4.1))
+        version: 8.4.5(react@18.3.1)(storybook@8.4.5(prettier@3.4.1))
       '@storybook/addon-onboarding':
         specifier: ^8.4.5
-        version: 8.4.5(react@19.0.0-rc.1)(storybook@8.4.5(prettier@3.4.1))
+        version: 8.4.5(react@18.3.1)(storybook@8.4.5(prettier@3.4.1))
       '@storybook/addon-storysource':
         specifier: ^8.4.5
         version: 8.4.5(storybook@8.4.5(prettier@3.4.1))
       '@storybook/blocks':
         specifier: ^8.4.5
-        version: 8.4.5(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1)(storybook@8.4.5(prettier@3.4.1))
+        version: 8.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.5(prettier@3.4.1))
       '@storybook/react':
         specifier: ^8.4.5
-        version: 8.4.5(@storybook/test@8.4.5(storybook@8.4.5(prettier@3.4.1)))(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1)(storybook@8.4.5(prettier@3.4.1))(typescript@5.7.2)
+        version: 8.4.5(@storybook/test@8.4.5(storybook@8.4.5(prettier@3.4.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.5(prettier@3.4.1))(typescript@5.7.2)
       '@storybook/react-vite':
         specifier: ^8.4.5
-        version: 8.4.5(@storybook/test@8.4.5(storybook@8.4.5(prettier@3.4.1)))(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1)(rollup@4.27.4)(storybook@8.4.5(prettier@3.4.1))(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.0))
+        version: 8.4.5(@storybook/test@8.4.5(storybook@8.4.5(prettier@3.4.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.27.4)(storybook@8.4.5(prettier@3.4.1))(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.0))
       '@storybook/test':
         specifier: ^8.4.5
         version: 8.4.5(storybook@8.4.5(prettier@3.4.1))
       '@types/node':
         specifier: ^22.10.0
         version: 22.10.0
+      '@types/react':
+        specifier: ^18.3.5
+        version: 18.3.12
+      '@types/react-dom':
+        specifier: ^18.3.0
+        version: 18.3.5(@types/react@18.3.12)
       '@vitejs/plugin-react-swc':
         specifier: ^3.7.2
         version: 3.7.2(vite@5.4.11(@types/node@22.10.0))
@@ -61,11 +60,11 @@ importers:
         specifier: ^3.4.1
         version: 3.4.1
       react:
-        specifier: 19.0.0-rc.1
-        version: 19.0.0-rc.1
+        specifier: 18.3.1
+        version: 18.3.1
       react-dom:
-        specifier: 19.0.0-rc.1
-        version: 19.0.0-rc.1(react@19.0.0-rc.1)
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
       storybook:
         specifier: ^8.4.5
         version: 8.4.5(prettier@3.4.1)
@@ -978,6 +977,11 @@ packages:
   '@types/prop-types@15.7.13':
     resolution: {integrity: sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==}
 
+  '@types/react-dom@18.3.5':
+    resolution: {integrity: sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
   '@types/react@18.3.12':
     resolution: {integrity: sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==}
 
@@ -1789,20 +1793,11 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
-  react-dom@19.0.0-rc.1:
-    resolution: {integrity: sha512-k8MfDX+4G+eaa1cXXI9QF4d+pQtYol3nx8vauqRWUEOPqC7NQn2qmEqUsLoSd28rrZUL+R3T2VC+kZ2Hyx1geQ==}
-    peerDependencies:
-      react: 19.0.0-rc.1
-
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
-    engines: {node: '>=0.10.0'}
-
-  react@19.0.0-rc.1:
-    resolution: {integrity: sha512-NZKln+uyPuyHchzP07I6GGYFxdAoaKhehgpCa3ltJGzwE31OYumLeshGaitA1R/fS5d9D2qpZVwTFAr6zCLM9w==}
     engines: {node: '>=0.10.0'}
 
   read-cache@1.0.0:
@@ -1849,9 +1844,6 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
-
-  scheduler@0.25.0-rc.1:
-    resolution: {integrity: sha512-fVinv2lXqYpKConAMdergOl5owd0rY1O4P/QTe0aWKCqGtu7VsCt1iqQFxSJtqK4Lci/upVSBpGwVC7eWcuS9Q==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -2057,12 +2049,6 @@ packages:
   type-fest@2.19.0:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
-
-  types-react-dom@19.0.0-rc.1:
-    resolution: {integrity: sha512-VSLZJl8VXCD0fAWp7DUTFUDCcZ8DVXOQmjhJMD03odgeFmu14ZQJHCXeETm3BEAhJqfgJaFkLnGkQv88sRx0fQ==}
-
-  types-react@19.0.0-rc.1:
-    resolution: {integrity: sha512-RshndUfqTW6K3STLPis8BtAYCGOkMbtvYsi90gmVNDZBXUyUc5juf2PE9LfS/JmOlUIRO8cWTS/1MTnmhjDqyQ==}
 
   typescript@5.7.2:
     resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
@@ -2293,12 +2279,12 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@chromatic-com/storybook@1.9.0(react@19.0.0-rc.1)':
+  '@chromatic-com/storybook@1.9.0(react@18.3.1)':
     dependencies:
       chromatic: 11.19.0
       filesize: 10.1.6
       jsonfile: 6.1.0
-      react-confetti: 6.1.0(react@19.0.0-rc.1)
+      react-confetti: 6.1.0(react@18.3.1)
       strip-ansi: 7.1.0
     transitivePeerDependencies:
       - '@chromatic-com/cypress'
@@ -2484,10 +2470,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@mdx-js/react@3.1.0(react@18.3.1)(types-react@19.0.0-rc.1)':
+  '@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1)':
     dependencies:
       '@types/mdx': 2.0.13
-      '@types/react': types-react@19.0.0-rc.1
+      '@types/react': 18.3.12
       react: 18.3.1
 
   '@nodelib/fs.scandir@2.1.5':
@@ -2590,9 +2576,9 @@ snapshots:
       storybook: 8.4.5(prettier@3.4.1)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-docs@8.4.5(storybook@8.4.5(prettier@3.4.1))(types-react@19.0.0-rc.1)':
+  '@storybook/addon-docs@8.4.5(@types/react@18.3.12)(storybook@8.4.5(prettier@3.4.1))':
     dependencies:
-      '@mdx-js/react': 3.1.0(react@18.3.1)(types-react@19.0.0-rc.1)
+      '@mdx-js/react': 3.1.0(@types/react@18.3.12)(react@18.3.1)
       '@storybook/blocks': 8.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.5(prettier@3.4.1))
       '@storybook/csf-plugin': 8.4.5(storybook@8.4.5(prettier@3.4.1))
       '@storybook/react-dom-shim': 8.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.5(prettier@3.4.1))
@@ -2603,12 +2589,12 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-essentials@8.4.5(storybook@8.4.5(prettier@3.4.1))(types-react@19.0.0-rc.1)':
+  '@storybook/addon-essentials@8.4.5(@types/react@18.3.12)(storybook@8.4.5(prettier@3.4.1))':
     dependencies:
       '@storybook/addon-actions': 8.4.5(storybook@8.4.5(prettier@3.4.1))
       '@storybook/addon-backgrounds': 8.4.5(storybook@8.4.5(prettier@3.4.1))
       '@storybook/addon-controls': 8.4.5(storybook@8.4.5(prettier@3.4.1))
-      '@storybook/addon-docs': 8.4.5(storybook@8.4.5(prettier@3.4.1))(types-react@19.0.0-rc.1)
+      '@storybook/addon-docs': 8.4.5(@types/react@18.3.12)(storybook@8.4.5(prettier@3.4.1))
       '@storybook/addon-highlight': 8.4.5(storybook@8.4.5(prettier@3.4.1))
       '@storybook/addon-measure': 8.4.5(storybook@8.4.5(prettier@3.4.1))
       '@storybook/addon-outline': 8.4.5(storybook@8.4.5(prettier@3.4.1))
@@ -2633,14 +2619,14 @@ snapshots:
       storybook: 8.4.5(prettier@3.4.1)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-links@8.4.5(react@19.0.0-rc.1)(storybook@8.4.5(prettier@3.4.1))':
+  '@storybook/addon-links@8.4.5(react@18.3.1)(storybook@8.4.5(prettier@3.4.1))':
     dependencies:
       '@storybook/csf': 0.1.11
       '@storybook/global': 5.0.0
       storybook: 8.4.5(prettier@3.4.1)
       ts-dedent: 2.2.0
     optionalDependencies:
-      react: 19.0.0-rc.1
+      react: 18.3.1
 
   '@storybook/addon-measure@8.4.5(storybook@8.4.5(prettier@3.4.1))':
     dependencies:
@@ -2648,9 +2634,9 @@ snapshots:
       storybook: 8.4.5(prettier@3.4.1)
       tiny-invariant: 1.3.3
 
-  '@storybook/addon-onboarding@8.4.5(react@19.0.0-rc.1)(storybook@8.4.5(prettier@3.4.1))':
+  '@storybook/addon-onboarding@8.4.5(react@18.3.1)(storybook@8.4.5(prettier@3.4.1))':
     dependencies:
-      react-confetti: 6.1.0(react@19.0.0-rc.1)
+      react-confetti: 6.1.0(react@18.3.1)
       storybook: 8.4.5(prettier@3.4.1)
     transitivePeerDependencies:
       - react
@@ -2686,16 +2672,6 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@storybook/blocks@8.4.5(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1)(storybook@8.4.5(prettier@3.4.1))':
-    dependencies:
-      '@storybook/csf': 0.1.11
-      '@storybook/icons': 1.2.12(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1)
-      storybook: 8.4.5(prettier@3.4.1)
-      ts-dedent: 2.2.0
-    optionalDependencies:
-      react: 19.0.0-rc.1
-      react-dom: 19.0.0-rc.1(react@19.0.0-rc.1)
 
   '@storybook/builder-vite@8.4.5(storybook@8.4.5(prettier@3.4.1))(vite@5.4.11(@types/node@22.10.0))':
     dependencies:
@@ -2745,11 +2721,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/icons@1.2.12(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1)':
-    dependencies:
-      react: 19.0.0-rc.1
-      react-dom: 19.0.0-rc.1(react@19.0.0-rc.1)
-
   '@storybook/instrumenter@8.4.5(storybook@8.4.5(prettier@3.4.1))':
     dependencies:
       '@storybook/global': 5.0.0
@@ -2770,23 +2741,17 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.4.5(prettier@3.4.1)
 
-  '@storybook/react-dom-shim@8.4.5(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1)(storybook@8.4.5(prettier@3.4.1))':
-    dependencies:
-      react: 19.0.0-rc.1
-      react-dom: 19.0.0-rc.1(react@19.0.0-rc.1)
-      storybook: 8.4.5(prettier@3.4.1)
-
-  '@storybook/react-vite@8.4.5(@storybook/test@8.4.5(storybook@8.4.5(prettier@3.4.1)))(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1)(rollup@4.27.4)(storybook@8.4.5(prettier@3.4.1))(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.0))':
+  '@storybook/react-vite@8.4.5(@storybook/test@8.4.5(storybook@8.4.5(prettier@3.4.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.27.4)(storybook@8.4.5(prettier@3.4.1))(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.0))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.3.0(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.0))
       '@rollup/pluginutils': 5.1.3(rollup@4.27.4)
       '@storybook/builder-vite': 8.4.5(storybook@8.4.5(prettier@3.4.1))(vite@5.4.11(@types/node@22.10.0))
-      '@storybook/react': 8.4.5(@storybook/test@8.4.5(storybook@8.4.5(prettier@3.4.1)))(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1)(storybook@8.4.5(prettier@3.4.1))(typescript@5.7.2)
+      '@storybook/react': 8.4.5(@storybook/test@8.4.5(storybook@8.4.5(prettier@3.4.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.5(prettier@3.4.1))(typescript@5.7.2)
       find-up: 5.0.0
       magic-string: 0.30.14
-      react: 19.0.0-rc.1
+      react: 18.3.1
       react-docgen: 7.1.0
-      react-dom: 19.0.0-rc.1(react@19.0.0-rc.1)
+      react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.8
       storybook: 8.4.5(prettier@3.4.1)
       tsconfig-paths: 4.2.0
@@ -2797,16 +2762,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@storybook/react@8.4.5(@storybook/test@8.4.5(storybook@8.4.5(prettier@3.4.1)))(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1)(storybook@8.4.5(prettier@3.4.1))(typescript@5.7.2)':
+  '@storybook/react@8.4.5(@storybook/test@8.4.5(storybook@8.4.5(prettier@3.4.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.5(prettier@3.4.1))(typescript@5.7.2)':
     dependencies:
       '@storybook/components': 8.4.5(storybook@8.4.5(prettier@3.4.1))
       '@storybook/global': 5.0.0
       '@storybook/manager-api': 8.4.5(storybook@8.4.5(prettier@3.4.1))
       '@storybook/preview-api': 8.4.5(storybook@8.4.5(prettier@3.4.1))
-      '@storybook/react-dom-shim': 8.4.5(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1)(storybook@8.4.5(prettier@3.4.1))
+      '@storybook/react-dom-shim': 8.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.5(prettier@3.4.1))
       '@storybook/theming': 8.4.5(storybook@8.4.5(prettier@3.4.1))
-      react: 19.0.0-rc.1
-      react-dom: 19.0.0-rc.1(react@19.0.0-rc.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       storybook: 8.4.5(prettier@3.4.1)
     optionalDependencies:
       '@storybook/test': 8.4.5(storybook@8.4.5(prettier@3.4.1))
@@ -2954,6 +2919,10 @@ snapshots:
       undici-types: 6.20.0
 
   '@types/prop-types@15.7.13': {}
+
+  '@types/react-dom@18.3.5(@types/react@18.3.12)':
+    dependencies:
+      '@types/react': 18.3.12
 
   '@types/react@18.3.12':
     dependencies:
@@ -3673,9 +3642,9 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  react-confetti@6.1.0(react@19.0.0-rc.1):
+  react-confetti@6.1.0(react@18.3.1):
     dependencies:
-      react: 19.0.0-rc.1
+      react: 18.3.1
       tween-functions: 1.2.0
 
   react-docgen-typescript@2.2.2(typescript@5.7.2):
@@ -3703,18 +3672,11 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-dom@19.0.0-rc.1(react@19.0.0-rc.1):
-    dependencies:
-      react: 19.0.0-rc.1
-      scheduler: 0.25.0-rc.1
-
   react-is@17.0.2: {}
 
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
-
-  react@19.0.0-rc.1: {}
 
   read-cache@1.0.0:
     dependencies:
@@ -3782,8 +3744,6 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
-
-  scheduler@0.25.0-rc.1: {}
 
   semver@6.3.1: {}
 
@@ -4000,14 +3960,6 @@ snapshots:
   tween-functions@1.2.0: {}
 
   type-fest@2.19.0: {}
-
-  types-react-dom@19.0.0-rc.1:
-    dependencies:
-      '@types/react': 18.3.12
-
-  types-react@19.0.0-rc.1:
-    dependencies:
-      csstype: 3.1.3
 
   typescript@5.7.2: {}
 


### PR DESCRIPTION
## Description

This pull request downgrades the `React` and `React-DOM` dependencies to continue with the strategy discussed in issue #66 due to the incompatibility of the components between React 18 and React 19 versions. As a result, the `master` branch will contain the dependencies that work with React 18, and the `beta` branch will contain the dependencies for React 19. This approach ensures better compatibility for users regardless of the React version they are using in their projects.

The strategy involves having two versions of the packages:
- The first version is the stable version that contains the components for React 18.
- The second version is the beta version that contains the components for React 19.

This information has been added to the `README.md` file to inform users about the two versions and how to install them based on the React version they are using.

Finally, two new sections have been added to the `README.md` file to mention the current and future strategies:
- Version Compatibility
- Notes
- Installation for React 18
- Installation for React 19

### Key Changes
- Downgrade `React` and `React-DOM` to version `18`
- Update `README.md` file with new sections

## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
