### PR TITLE
chore(release): bump package versions

### DIFF
--- a/packages/ui-button/package.json
+++ b/packages/ui-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-button",
-  "version": "0.3.2",
+  "version": "0.3.2-beta.0",
   "description": "A customizable button component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",
   "scripts": {

--- a/packages/ui-checkbox/package.json
+++ b/packages/ui-checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-checkbox",
-  "version": "0.1.0",
+  "version": "0.1.0-beta.0",
   "private": false,
   "description": "A customizable Checkbox component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-core",
-  "version": "0.2.1",
+  "version": "0.2.1-beta.0",
   "description": "The core of the @halvaradop/ui library, providing customizable components with Tailwind CSS styling.",
   "type": "module",
   "scripts": {

--- a/packages/ui-dialog/package.json
+++ b/packages/ui-dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-dialog",
-  "version": "0.1.2",
+  "version": "0.1.2-beta.0",
   "private": false,
   "description": "A customizable dialog component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",

--- a/packages/ui-form/package.json
+++ b/packages/ui-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-form",
-  "version": "0.1.2",
+  "version": "0.1.2-beta.0",
   "private": false,
   "description": "A customizable form component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",

--- a/packages/ui-input/package.json
+++ b/packages/ui-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-input",
-  "version": "0.2.2",
+  "version": "0.2.2-beta.0",
   "private": false,
   "description": "A customizable input component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",

--- a/packages/ui-label/package.json
+++ b/packages/ui-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-label",
-  "version": "0.1.2",
+  "version": "0.1.2-beta.0",
   "private": false,
   "description": "A customizable label component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",

--- a/packages/ui-submit/package.json
+++ b/packages/ui-submit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-submit",
-  "version": "0.1.0",
+  "version": "0.1.0-beta.0",
   "private": false,
   "description": "A customizable submit component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",

--- a/packages/ui-template/package.json
+++ b/packages/ui-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-template",
-  "version": "0.1.0",
+  "version": "0.1.0-beta.0",
   "private": false,
   "description": "A customizable {_} component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",


### PR DESCRIPTION
## Description


This pull request publishes new versions of the packages provided by the `@halvaradop/ui` library of components with the beta tag to support compatibility with React 19. The updates to these packages address the issue discussed in issue #66 regarding the incompatibility of the components with React 18 and React 19.

### Published Packages
- `@halvaradop/ui-button@beta`
- `@halvaradop/ui-checkbox@beta`
- `@halvaradop/ui-core@beta`
- `@halvaradop/ui-dialog@beta`
- `@halvaradop/ui-form@beta`
- `@halvaradop/ui-input@beta`
- `@halvaradop/ui-label@beta`
- `@halvaradop/ui-submit@beta`

These updates ensure that users can seamlessly use the components with React 19 while maintaining the existing functionality with React 18.


## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
