### PR TITLE
feat: add `ComponentProps` and `WithChildrenProps` types

### DIFF
--- a/packages/ui-button/src/index.tsx
+++ b/packages/ui-button/src/index.tsx
@@ -1,4 +1,4 @@
-import { merge, Slot, type SlotProps, ArgsFunction } from "@halvaradop/ui-core"
+import { merge, Slot, type SlotProps, type ArgsFunction } from "@halvaradop/ui-core"
 import { cva, type VariantProps } from "class-variance-authority"
 
 export type ButtonProps<T extends ArgsFunction> = SlotProps<"button"> & VariantProps<T>

--- a/packages/ui-checkbox/src/index.tsx
+++ b/packages/ui-checkbox/src/index.tsx
@@ -1,8 +1,7 @@
-import { ComponentProps } from "react"
-import { merge, type ArgsFunction } from "@halvaradop/ui-core"
+import { merge, type ComponentProps, type ArgsFunction } from "@halvaradop/ui-core"
 import { cva, type VariantProps } from "class-variance-authority"
 
-export type CheckboxProps<T extends ArgsFunction> = VariantProps<T> & Omit<ComponentProps<"input">, "type" | "size">
+export type CheckboxProps<T extends ArgsFunction> = VariantProps<T> & ComponentProps<"input", "type" | "size">
 
 const internalVariants = cva("hidden absolute peer-checked:block", {
     variants: {

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -44,8 +44,6 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
-    "./package.json": "./package.json",
-    "./tsconfig.base.json": "./tsconfig.base.json",
     "./tsup.config.base": {
       "types": "./dist/tsup.config.base.d.ts",
       "import": "./dist/tsup.config.base.js",
@@ -56,15 +54,16 @@
       "import": "./dist/slot.js",
       "require": "./dist/slot.cjs"
     },
-    "./utility-types": {
-      "types": "./dist/utility-types.d.ts"
-    }
+    "./types": {
+      "types": "./dist/types.d.ts"
+    },
+    "./package.json": "./package.json",
+    "./tsconfig.base.json": "./tsconfig.base.json"
   },
   "dependencies": {
     "tailwind-merge": "^2.5.2"
   },
   "devDependencies": {
-    "@halvaradop/ts-utility-types": "0.15.0",
     "clsx": "^2.1.1"
   }
 }

--- a/packages/ui-core/src/index.ts
+++ b/packages/ui-core/src/index.ts
@@ -1,4 +1,7 @@
+/**
+ * @package @halvaradop/ui-core
+ */
 export * from "./tsup.config.base.js"
 export * from "./slot.js"
 export * from "./utils.js"
-export type * from "@halvaradop/ts-utility-types"
+export type * from "./types.js"

--- a/packages/ui-core/src/slot.ts
+++ b/packages/ui-core/src/slot.ts
@@ -1,4 +1,5 @@
-import { type ReactNode, Children, isValidElement, cloneElement, ComponentProps } from "react"
+import { type ReactNode, type ComponentProps, Children, isValidElement, cloneElement } from "react"
+import type { HTMLTag } from "./types.js"
 
 export const Slot = ({ children, ...props }: { children: React.ReactNode }) => {
     if (isValidElement(children)) {
@@ -13,14 +14,11 @@ export const Slot = ({ children, ...props }: { children: React.ReactNode }) => {
 /**
  * @internal
  */
-type SlotWithAsChild<
-    Component extends keyof React.JSX.IntrinsicElements | React.JSXElementConstructor<unknown>,
-    Element extends HTMLElement,
-> =
+type SlotWithAsChild<Component extends HTMLTag, Element extends HTMLElement> =
     | ({ asChild?: false } & ComponentProps<Component>)
     | { asChild: true; children: ReactNode; ref?: React.Ref<Element> | undefined }
 
-export type SlotProps<
-    Component extends keyof React.JSX.IntrinsicElements | React.JSXElementConstructor<unknown>,
-    Element extends HTMLElement = never,
-> = SlotWithAsChild<Component, Element> & { className?: string }
+export type SlotProps<Component extends HTMLTag, Element extends HTMLElement = never> = SlotWithAsChild<
+    Component,
+    Element
+> & { className?: string }

--- a/packages/ui-core/src/types.ts
+++ b/packages/ui-core/src/types.ts
@@ -1,0 +1,17 @@
+export type HTMLTag = keyof JSX.IntrinsicElements | React.JSXElementConstructor<unknown>
+
+export type WithChildrenProps<Props extends object> = Omit<Props, "children"> & { children: React.ReactNode }
+
+/**
+ * @unstable
+ */
+export type HTMLTagAttributes<Tag extends HTMLTag> = Tag extends keyof JSX.IntrinsicElements
+    ? JSX.IntrinsicElements[Tag]
+    : React.JSXElementConstructor<Tag>
+
+export type ComponentProps<Tag extends HTMLTag, ExcludedAttributes extends keyof HTMLTagAttributes<Tag> = never> = Omit<
+    HTMLTagAttributes<Tag>,
+    ExcludedAttributes
+>
+
+export type ArgsFunction = (...args: any) => void

--- a/packages/ui-core/src/utility-types.ts
+++ b/packages/ui-core/src/utility-types.ts
@@ -1,1 +1,0 @@
-export type * from "@halvaradop/ts-utility-types"

--- a/packages/ui-core/src/utils.ts
+++ b/packages/ui-core/src/utils.ts
@@ -4,11 +4,11 @@ import { clsx, ClassValue } from "clsx"
 /**
  * Merge multiple classes into a single class string. It prioritizes the
  * last class in case of conflicts.
- * @params classes - The classes to merge.
- * @returns The merged class string.
+ * @param {string} classes - The classes to merge.
+ * @returns {string} The merged class string.
  * @example
  * // Expected: "text-red-500"
- * merge("text-blue-500 text-red-500")
+ * merge("text-blue-500", " text-red-500")
  */
 export const merge = (...classes: ClassValue[]): string => {
     return twMerge(clsx(classes))

--- a/packages/ui-core/tsconfig.base.json
+++ b/packages/ui-core/tsconfig.base.json
@@ -15,7 +15,9 @@
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "baseUrl": "."
   },
   "include": ["src"]
 }

--- a/packages/ui-dialog/src/index.tsx
+++ b/packages/ui-dialog/src/index.tsx
@@ -1,8 +1,7 @@
-import type { ComponentProps } from "react"
-import { merge, type ArgsFunction } from "@halvaradop/ui-core"
+import { merge, type ComponentProps, type WithChildrenProps, type ArgsFunction } from "@halvaradop/ui-core"
 import { cva, type VariantProps } from "class-variance-authority"
 
-export type DialogProps<T extends ArgsFunction> = ComponentProps<"dialog"> & VariantProps<T>
+export type DialogProps<T extends ArgsFunction> = VariantProps<T> & WithChildrenProps<ComponentProps<"dialog">>
 
 export const innerDialogVariants = cva("flex items-center justify-center", {
     variants: {

--- a/packages/ui-form/src/index.tsx
+++ b/packages/ui-form/src/index.tsx
@@ -1,8 +1,7 @@
-import type { ComponentProps } from "react"
-import { merge, type ArgsFunction } from "@halvaradop/ui-core"
+import { merge, type WithChildrenProps, type ComponentProps, type ArgsFunction } from "@halvaradop/ui-core"
 import { cva, type VariantProps } from "class-variance-authority"
 
-export type FormProps<T extends ArgsFunction> = VariantProps<T> & ComponentProps<"form">
+export type FormProps<T extends ArgsFunction> = VariantProps<T> & WithChildrenProps<ComponentProps<"form">>
 
 export const formVariants = cva("mx-auto flex items-center flex-col relative", {
     variants: {

--- a/packages/ui-input/src/index.tsx
+++ b/packages/ui-input/src/index.tsx
@@ -1,8 +1,7 @@
-import type { ComponentProps } from "react"
-import { merge, type ArgsFunction } from "@halvaradop/ui-core"
+import { merge, type ComponentProps, type ArgsFunction } from "@halvaradop/ui-core"
 import { cva, type VariantProps } from "class-variance-authority"
 
-export type InputProps<T extends ArgsFunction> = Omit<ComponentProps<"input">, "size"> & VariantProps<T>
+export type InputProps<T extends ArgsFunction> = VariantProps<T> & ComponentProps<"input", "size">
 
 export const inputVariants = cva("text-slate-600 border focus-within:outline-none disabled:cursor-not-allowed disabled:text-gray-400 disabled:border-gray-300 disabled:bg-gray-100", {
     variants: {

--- a/packages/ui-radio-group/src/index.tsx
+++ b/packages/ui-radio-group/src/index.tsx
@@ -1,12 +1,9 @@
 "use client"
-import { ComponentProps, forwardRef, useEffect, useRef } from "react"
-import { merge, type ArgsFunction } from "@halvaradop/ui-core"
+import { forwardRef, useEffect, useRef } from "react"
+import { merge, type ComponentProps, type WithChildrenProps, type ArgsFunction } from "@halvaradop/ui-core"
 import { cva, type VariantProps } from "class-variance-authority"
 
-export type RadioGroupProps<T extends ArgsFunction> = VariantProps<T> &
-    Omit<ComponentProps<"fieldset">, "children"> & {
-        children: React.ReactNode
-    }
+export type RadioGroupProps<T extends ArgsFunction> = VariantProps<T> & WithChildrenProps<ComponentProps<"fieldset">>
 
 export const radioGroupVariants = cva("flex", {
     variants: {

--- a/packages/ui-radio/src/index.tsx
+++ b/packages/ui-radio/src/index.tsx
@@ -1,8 +1,7 @@
-import { ComponentProps } from "react"
-import { merge, type ArgsFunction } from "@halvaradop/ui-core"
+import { merge, type ComponentProps, type ArgsFunction } from "@halvaradop/ui-core"
 import { cva, type VariantProps } from "class-variance-authority"
 
-export type RadioProps<T extends ArgsFunction> = VariantProps<T> & Omit<ComponentProps<"input">, "type" | "size">
+export type RadioProps<T extends ArgsFunction> = VariantProps<T> & ComponentProps<"input", "type" | "size">
 
 export const radioVariants = cva("peer appearance-none rounded-full", {
     variants: {

--- a/packages/ui-submit/src/index.tsx
+++ b/packages/ui-submit/src/index.tsx
@@ -1,9 +1,12 @@
 "use client"
-import { ComponentProps } from "react"
-import { type ArgsFunction, merge } from "@halvaradop/ui-core"
+import { merge, type ComponentProps, type ArgsFunction } from "@halvaradop/ui-core"
 import { cva, VariantProps } from "class-variance-authority"
 
-export type SubmitProps<T extends ArgsFunction> = VariantProps<T> & Omit<ComponentProps<"input">, "type" | "size"> & { pending?: string }
+interface InternalSubmitProps {
+    pending?: string
+}
+
+export type SubmitProps<T extends ArgsFunction> = VariantProps<T> & ComponentProps<"input", "type" | "size"> & InternalSubmitProps
 
 export const submitVariants = cva("font-medium border focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-2 disabled:hover:cursor-progress", {
     variants: {

--- a/packages/ui-template/src/index.tsx
+++ b/packages/ui-template/src/index.tsx
@@ -1,5 +1,4 @@
-import { ComponentProps } from "react"
-import { merge, type ArgsFunction } from "@halvaradop/ui-core"
+import { merge, type ArgsFunction, type ComponentProps } from "@halvaradop/ui-core"
 import { cva, type VariantProps } from "class-variance-authority"
 
 export type IndexProps<T extends ArgsFunction> = VariantProps<T> & ComponentProps<"div">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,9 +108,6 @@ importers:
         specifier: ^2.5.2
         version: 2.6.0
     devDependencies:
-      '@halvaradop/ts-utility-types':
-        specifier: 0.15.0
-        version: 0.15.0
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -558,9 +555,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@halvaradop/ts-utility-types@0.15.0':
-    resolution: {integrity: sha512-e3AC/OnD6xn27ukp86UtdQlQKd82HLVSlNgk5JS6cKWWHWH5eTC860M6qm1RAILuIdL/a5r4BCdFxPgJAnY5qw==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2469,8 +2463,6 @@ snapshots:
 
   '@esbuild/win32-x64@0.24.2':
     optional: true
-
-  '@halvaradop/ts-utility-types@0.15.0': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:


### PR DESCRIPTION


## Description 
This pull request adds new types to improve access to the attributes of components based on the HTML tags used to build custom components. Additionally, the `@halvaradop/ts-utility-types` package was uninstalled due to its limited usage, and the required types were created to replace those from the removed dependency. The code has been updated to work correctly with the new types. 

### Key Changes 
- Add `HTMLTag` type 
- Add `WithChildrenProps` type 
- Add `HTMLTagAttributes` type -
-  Add `ComponentProps` type 
- Add `ArgsFunction` type to replace `@halvaradop/ts-utility-types` 
- Remove `ComponentProps` imported from `react` 
- Uninstall `@halvaradop/ts-utility-types`

## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
