### PR TITLE
chore: add missing `forwardRef` hook in components

### DIFF
--- a/packages/ui-button/src/index.tsx
+++ b/packages/ui-button/src/index.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react"
 import { merge, Slot, type SlotProps, type ArgsFunction } from "@halvaradop/ui-core"
 import { cva, type VariantProps } from "class-variance-authority"
 
@@ -35,13 +36,13 @@ export const buttonVariants = cva("flex items-center justify-center font-semibol
     },
 })
 
-export const Button = ({ className, variant, size, fullWidth, fullRounded, asChild, children, ref, ...props }: ButtonProps<typeof buttonVariants>) => {
+export const Button = forwardRef<HTMLButtonElement, ButtonProps<typeof buttonVariants>>(({ className, variant, size, fullWidth, fullRounded, asChild, children, ...props }, ref) => {
     const SlotComponent = asChild ? Slot : "button"
     return (
         <SlotComponent className={merge(buttonVariants({ className, variant, size, fullWidth, fullRounded }))} ref={ref} role="button" {...props}>
             {children}
         </SlotComponent>
     )
-}
+})
 
 Button.displayName = "Button"

--- a/packages/ui-checkbox/src/index.tsx
+++ b/packages/ui-checkbox/src/index.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react"
 import { merge, type ComponentProps, type ArgsFunction } from "@halvaradop/ui-core"
 import { cva, type VariantProps } from "class-variance-authority"
 
@@ -42,15 +43,15 @@ export const checkboxVariants = cva("appearance-none border border-gray-400 focu
     },
 })
 
-export const Checkbox = ({ className, size, color, name, ref }: CheckboxProps<typeof checkboxVariants>) => {
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps<typeof checkboxVariants>>(({ className, size, color, name, ...props }, ref) => {
     return (
         <label className="flex items-center justify-center relative" htmlFor={name}>
-            <input className={merge(checkboxVariants({ className, size, color }), "peer")} type="checkbox" name={name} ref={ref} />
+            <input className={merge(checkboxVariants({ className, size, color }), "peer")} type="checkbox" name={name} ref={ref} {...props} />
             <svg className={internalVariants({ size })} xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" fill="#fff">
                 <path d="M382-240 154-468l57-57 171 171 367-367 57 57-424 424Z" />
             </svg>
         </label>
     )
-}
+})
 
 Checkbox.displayName = "Checkbox"

--- a/packages/ui-dialog/src/index.tsx
+++ b/packages/ui-dialog/src/index.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react"
 import { merge, type ComponentProps, type WithChildrenProps, type ArgsFunction } from "@halvaradop/ui-core"
 import { cva, type VariantProps } from "class-variance-authority"
 
@@ -23,12 +24,12 @@ export const innerDialogVariants = cva("flex items-center justify-center", {
     },
 })
 
-export const Modal = ({ className, children, ref, ...props }: DialogProps<typeof innerDialogVariants>) => {
+export const Modal = forwardRef<HTMLDialogElement, DialogProps<typeof innerDialogVariants>>(({ className, children, ...props }, ref) => {
     return (
         <dialog className={merge("w-full min-h-screen max-w-none max-h-none items-center justify-center relative inset-0 bg-transparent backdrop:bg-slate-500/50 open:flex", className)} ref={ref} {...props}>
             {children}
         </dialog>
     )
-}
+})
 
 Modal.displayName = "Dialog"

--- a/packages/ui-form/src/index.tsx
+++ b/packages/ui-form/src/index.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react"
 import { merge, type WithChildrenProps, type ComponentProps, type ArgsFunction } from "@halvaradop/ui-core"
 import { cva, type VariantProps } from "class-variance-authority"
 
@@ -24,12 +25,12 @@ export const formVariants = cva("mx-auto flex items-center flex-col relative", {
     },
 })
 
-export const Form = ({ className, variant, size, children, ref, ...props }: FormProps<typeof formVariants>) => {
+export const Form = forwardRef<HTMLFormElement, FormProps<typeof formVariants>>(({ className, variant, size, children, ...props }, ref) => {
     return (
         <form className={merge(formVariants({ className, variant, size }))} ref={ref} {...props}>
             {children}
         </form>
     )
-}
+})
 
 Form.displayName = "Form"

--- a/packages/ui-input/src/index.tsx
+++ b/packages/ui-input/src/index.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react"
 import { merge, type ComponentProps, type ArgsFunction } from "@halvaradop/ui-core"
 import { cva, type VariantProps } from "class-variance-authority"
 
@@ -34,8 +35,8 @@ export const inputVariants = cva("text-slate-600 border focus-within:outline-non
     },
 })
 
-export const Input = ({ className, variant, size, fullWidth, fullRounded, type, ref, ...props }: InputProps<typeof inputVariants>) => {
+export const Input = forwardRef<HTMLInputElement, InputProps<typeof inputVariants>>(({ className, variant, size, fullWidth, fullRounded, type, ...props }, ref) => {
     return <input className={merge(inputVariants({ className, variant, size, fullWidth, fullRounded }))} type={type} ref={ref} {...props} />
-}
+})
 
 Input.displayName = "Input"

--- a/packages/ui-label/src/index.tsx
+++ b/packages/ui-label/src/index.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react"
 import { merge, Slot, type SlotProps, type ArgsFunction } from "@halvaradop/ui-core"
 import { cva, type VariantProps } from "class-variance-authority"
 
@@ -22,13 +23,13 @@ export const labelVariants = cva("font-medium relative leading-none", {
     },
 })
 
-export const Label = ({ className, variant, size, children, asChild, ref, ...props }: LabelProps<typeof labelVariants>) => {
+export const Label = forwardRef<HTMLLabelElement, LabelProps<typeof labelVariants>>(({ className, variant, size, children, asChild, ...props }, ref) => {
     const SlotComponent = asChild ? Slot : "label"
     return (
         <SlotComponent className={merge(labelVariants({ className, variant, size }))} ref={ref} {...props}>
             {children}
         </SlotComponent>
     )
-}
+})
 
 Label.displayName = "Label"

--- a/packages/ui-radio/src/index.tsx
+++ b/packages/ui-radio/src/index.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react"
 import { merge, type ComponentProps, type ArgsFunction } from "@halvaradop/ui-core"
 import { cva, type VariantProps } from "class-variance-authority"
 
@@ -47,13 +48,13 @@ const internalVariants = cva("block absolute rounded-full", {
     },
 })
 
-export const Radio = ({ className, size, color, name, ...props }: RadioProps<typeof radioVariants & typeof internalVariants>) => {
+export const Radio = forwardRef<HTMLInputElement, RadioProps<typeof radioVariants & typeof internalVariants>>(({ className, size, color, name, ...props }, ref) => {
     return (
         <label className="w-min inline-flex items-center justify-center relative" htmlFor={name}>
-            <input className={merge(radioVariants({ className, size, color }))} type="radio" name={name} {...props} />
+            <input className={merge(radioVariants({ className, size, color }))} type="radio" name={name} ref={ref} {...props} />
             <span className={internalVariants({ size, color })} />
         </label>
     )
-}
+})
 
 Radio.displayName = "Radio"

--- a/packages/ui-submit/src/index.tsx
+++ b/packages/ui-submit/src/index.tsx
@@ -1,4 +1,4 @@
-"use client"
+import { forwardRef } from "react"
 import { merge, type ComponentProps, type ArgsFunction } from "@halvaradop/ui-core"
 import { cva, VariantProps } from "class-variance-authority"
 
@@ -36,9 +36,9 @@ export const submitVariants = cva("font-medium border focus-within:outline-none 
     },
 })
 
-export const Submit = ({ className, variant, size, fullWidth, fullRounded, value = "Submit", pending = "Submitting...", disabled, ref, ...props }: SubmitProps<typeof submitVariants>) => {
+export const Submit = forwardRef<HTMLInputElement, SubmitProps<typeof submitVariants>>(({ className, variant, size, fullWidth, fullRounded, value = "Submit", pending = "Submitting...", disabled, ...props }, ref) => {
     const message = disabled ? pending : value
     return <input className={merge(submitVariants({ className, variant, size, fullWidth, fullRounded }))} type="submit" value={message} disabled={disabled} aria-disabled={disabled} ref={ref} {...props} />
-}
+})
 
 Submit.displayName = "Input"

--- a/packages/ui-template/src/index.tsx
+++ b/packages/ui-template/src/index.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react"
 import { merge, type ArgsFunction, type ComponentProps } from "@halvaradop/ui-core"
 import { cva, type VariantProps } from "class-variance-authority"
 
@@ -7,6 +8,6 @@ export const indexVariants = cva("", {
     variants: {},
 })
 
-export const Index = () => {
+export const Index = forwardRef(() => {
     return <div></div>
-}
+})


### PR DESCRIPTION
## Description

This pull request reintroduces the missing `forwardRef` hook in components to work with the `useRef` hook provided by React. These hooks were re-added because in a previous pull request (#58), they were removed when the React and ReactDOM dependencies were updated to version 19, which does not require this hook to work with references. However, in React and ReactDOM version 18, this hook is required to work with references. Therefore, the `forwardRef` hook has been re-added to the components.

## Checklist

- [ ] Added documentation.
- [ ] The changes do not generate any warnings.
- [ ] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
