### PR TITLE
chore(prettier): remove `.tsx` file options and run `format`

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,14 +96,6 @@
         "options": {
           "tabWidth": 2
         }
-      },
-      {
-        "files": [
-          "**/*.tsx"
-        ],
-        "options": {
-          "printWidth": 300
-        }
       }
     ]
   }

--- a/packages/ui-button/src/button.stories.tsx
+++ b/packages/ui-button/src/button.stories.tsx
@@ -30,7 +30,10 @@ const meta: Meta = {
             }, [])
 
             return (
-                <div className="w-full h-full mx-auto flex items-center justify-center absolute inset-0 data-[dark='true']:bg-black" data-dark={isDark}>
+                <div
+                    className="w-full h-full mx-auto flex items-center justify-center absolute inset-0 data-[dark='true']:bg-black"
+                    data-dark={isDark}
+                >
                     <div className="w-full dark:text-white">
                         <Button className="absolute top-[4%] left-[4%]" onClick={handleToggleTheme}>
                             Theme

--- a/packages/ui-button/src/index.tsx
+++ b/packages/ui-button/src/index.tsx
@@ -4,46 +4,59 @@ import { cva, type VariantProps } from "class-variance-authority"
 
 export type ButtonProps<T extends ArgsFunction> = SlotProps<"button"> & VariantProps<T>
 
-export const buttonVariants = cva("flex items-center justify-center font-semibold border border-solid transition-colors hover:bg-opacity-90 focus-visible:[outline-style:solid] focus-visible:outline-2 focus-visible:outline-offset-2", {
-    variants: {
-        variant: {
-            base: "text-color-100 border-primary bg-primary hover:border-primary-hover hover:bg-primary-hover focus-visible:outline-primary-hover",
-            secondary: "text-color-200 border-secondary bg-secondary hover:border-secondary-hover hover:bg-secondary-hover focus-visible:outline-secondary",
-            ghost: "text-color-200 border-transparent bg-transparent hover:bg-ghost focus-visible:outline-ghost dark:hover:text-color-100",
-            link: "text-color-200 border-none hover:underline hover:underline-offset-8 hover:decoration-primary focus-visible:underline focus-visible:underline-offset-8 focus-visible:outline-none",
-            destructive: "text-white border-red bg-red hover:border-red-hover hover:bg-red-hover focus-visible:outline-red",
-            outline: "text-color-200 border-ghost hover:bg-ghost focus-visible:outline-ghost dark:hover:text-color-100",
-            plain: "text-color-200 border-transparent focus-visible:outline-primary",
+export const buttonVariants = cva(
+    "flex items-center justify-center font-semibold border border-solid transition-colors hover:bg-opacity-90 focus-visible:[outline-style:solid] focus-visible:outline-2 focus-visible:outline-offset-2",
+    {
+        variants: {
+            variant: {
+                base: "text-color-100 border-primary bg-primary hover:border-primary-hover hover:bg-primary-hover focus-visible:outline-primary-hover",
+                secondary:
+                    "text-color-200 border-secondary bg-secondary hover:border-secondary-hover hover:bg-secondary-hover focus-visible:outline-secondary",
+                ghost: "text-color-200 border-transparent bg-transparent hover:bg-ghost focus-visible:outline-ghost dark:hover:text-color-100",
+                link: "text-color-200 border-none hover:underline hover:underline-offset-8 hover:decoration-primary focus-visible:underline focus-visible:underline-offset-8 focus-visible:outline-none",
+                destructive:
+                    "text-white border-red bg-red hover:border-red-hover hover:bg-red-hover focus-visible:outline-red",
+                outline:
+                    "text-color-200 border-ghost hover:bg-ghost focus-visible:outline-ghost dark:hover:text-color-100",
+                plain: "text-color-200 border-transparent focus-visible:outline-primary",
+            },
+            size: {
+                sm: "h-9 px-3 text-sm rounded-md",
+                base: "h-10 px-4 text-base rounded-md",
+                md: "h-11 px-4 text-base rounded-md",
+                lg: "h-12 px-4 text-lg rounded-lg",
+            },
+            fullWidth: {
+                true: "w-full",
+                false: "w-fit",
+            },
+            fullRounded: {
+                true: "rounded-full",
+            },
         },
-        size: {
-            sm: "h-9 px-3 text-sm rounded-md",
-            base: "h-10 px-4 text-base rounded-md",
-            md: "h-11 px-4 text-base rounded-md",
-            lg: "h-12 px-4 text-lg rounded-lg",
+        defaultVariants: {
+            variant: "base",
+            size: "base",
+            fullWidth: false,
+            fullRounded: false,
         },
-        fullWidth: {
-            true: "w-full",
-            false: "w-fit",
-        },
-        fullRounded: {
-            true: "rounded-full",
-        },
-    },
-    defaultVariants: {
-        variant: "base",
-        size: "base",
-        fullWidth: false,
-        fullRounded: false,
-    },
-})
+    }
+)
 
-export const Button = forwardRef<HTMLButtonElement, ButtonProps<typeof buttonVariants>>(({ className, variant, size, fullWidth, fullRounded, asChild, children, ...props }, ref) => {
-    const SlotComponent = asChild ? Slot : "button"
-    return (
-        <SlotComponent className={merge(buttonVariants({ className, variant, size, fullWidth, fullRounded }))} ref={ref} role="button" {...props}>
-            {children}
-        </SlotComponent>
-    )
-})
+export const Button = forwardRef<HTMLButtonElement, ButtonProps<typeof buttonVariants>>(
+    ({ className, variant, size, fullWidth, fullRounded, asChild, children, ...props }, ref) => {
+        const SlotComponent = asChild ? Slot : "button"
+        return (
+            <SlotComponent
+                className={merge(buttonVariants({ className, variant, size, fullWidth, fullRounded }))}
+                ref={ref}
+                role="button"
+                {...props}
+            >
+                {children}
+            </SlotComponent>
+        )
+    }
+)
 
 Button.displayName = "Button"

--- a/packages/ui-checkbox/src/checkbox.stories.tsx
+++ b/packages/ui-checkbox/src/checkbox.stories.tsx
@@ -28,7 +28,10 @@ const meta: Meta = {
             }, [])
 
             return (
-                <div className="w-full h-full mx-auto flex items-center justify-center absolute inset-0 data-[dark='true']:bg-black" data-dark={isDark}>
+                <div
+                    className="w-full h-full mx-auto flex items-center justify-center absolute inset-0 data-[dark='true']:bg-black"
+                    data-dark={isDark}
+                >
                     <div className="w-full dark:text-white">
                         <Button className="absolute top-[4%] left-[4%]" onClick={handleToggleTheme}>
                             Theme

--- a/packages/ui-checkbox/src/index.tsx
+++ b/packages/ui-checkbox/src/index.tsx
@@ -18,40 +18,56 @@ const internalVariants = cva("hidden absolute peer-checked:block", {
     },
 })
 
-export const checkboxVariants = cva("appearance-none border border-gray-400 focus-visible:[outline-style:solid] focus-visible:outline-gray-400", {
-    variants: {
-        size: {
-            sm: "size-3 rounded-[1px] focus-visible:outline focus-visible:outline-offset-1",
-            base: "size-4 rounded-sm focus-visible:outline focus-visible:outline-offset-1",
-            md: "size-5 p-0.5 rounded-[4px] focus-visible:outline-2 focus-visible:outline-offset-2",
-            lg: "size-6 p-0.5 rounded-[5px] focus-visible:outline-2 focus-visible:outline-offset-2",
+export const checkboxVariants = cva(
+    "appearance-none border border-gray-400 focus-visible:[outline-style:solid] focus-visible:outline-gray-400",
+    {
+        variants: {
+            size: {
+                sm: "size-3 rounded-[1px] focus-visible:outline focus-visible:outline-offset-1",
+                base: "size-4 rounded-sm focus-visible:outline focus-visible:outline-offset-1",
+                md: "size-5 p-0.5 rounded-[4px] focus-visible:outline-2 focus-visible:outline-offset-2",
+                lg: "size-6 p-0.5 rounded-[5px] focus-visible:outline-2 focus-visible:outline-offset-2",
+            },
+            color: {
+                green: "checked:border-green checked:bg-green checked:focus-visible:outline-green",
+                blue: "checked:border-blue checked:bg-blue checked:focus-visible:outline-blue",
+                red: "checked:border-red checked:bg-red checked:focus-visible:outline-red",
+                yellow: "checked:border-yellow checked:bg-yellow checked:focus-visible:outline-yellow",
+                primary: "checked:border-primary checked:bg-primary checked:focus-visible:outline-primary",
+            },
+            fullRounded: {
+                true: "rounded-full",
+            },
         },
-        color: {
-            green: "checked:border-green checked:bg-green checked:focus-visible:outline-green",
-            blue: "checked:border-blue checked:bg-blue checked:focus-visible:outline-blue",
-            red: "checked:border-red checked:bg-red checked:focus-visible:outline-red",
-            yellow: "checked:border-yellow checked:bg-yellow checked:focus-visible:outline-yellow",
-            primary: "checked:border-primary checked:bg-primary checked:focus-visible:outline-primary",
+        defaultVariants: {
+            size: "base",
+            color: "green",
         },
-        fullRounded: {
-            true: "rounded-full",
-        },
-    },
-    defaultVariants: {
-        size: "base",
-        color: "green",
-    },
-})
+    }
+)
 
-export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps<typeof checkboxVariants>>(({ className, size, color, name, ...props }, ref) => {
-    return (
-        <label className="flex items-center justify-center relative" htmlFor={name}>
-            <input className={merge(checkboxVariants({ className, size, color }), "peer")} type="checkbox" name={name} ref={ref} {...props} />
-            <svg className={internalVariants({ size })} xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" fill="#fff">
-                <path d="M382-240 154-468l57-57 171 171 367-367 57 57-424 424Z" />
-            </svg>
-        </label>
-    )
-})
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps<typeof checkboxVariants>>(
+    ({ className, size, color, name, ...props }, ref) => {
+        return (
+            <label className="flex items-center justify-center relative" htmlFor={name}>
+                <input
+                    className={merge(checkboxVariants({ className, size, color }), "peer")}
+                    type="checkbox"
+                    name={name}
+                    ref={ref}
+                    {...props}
+                />
+                <svg
+                    className={internalVariants({ size })}
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 -960 960 960"
+                    fill="#fff"
+                >
+                    <path d="M382-240 154-468l57-57 171 171 367-367 57 57-424 424Z" />
+                </svg>
+            </label>
+        )
+    }
+)
 
 Checkbox.displayName = "Checkbox"

--- a/packages/ui-dialog/src/dialog.stories.tsx
+++ b/packages/ui-dialog/src/dialog.stories.tsx
@@ -27,7 +27,10 @@ const meta: Meta = {
                 setIsDark(document.querySelector("html")?.classList?.contains("dark") ?? false)
             }, [])
             return (
-                <div className="w-full h-full mx-auto flex items-center justify-center absolute inset-0 data-[dark='true']:bg-black" data-dark={isDark}>
+                <div
+                    className="w-full h-full mx-auto flex items-center justify-center absolute inset-0 data-[dark='true']:bg-black"
+                    data-dark={isDark}
+                >
                     <div className="w-full dark:text-white">
                         <Button className="absolute top-[4%] left-[4%]" onClick={handleToggleTheme}>
                             Theme

--- a/packages/ui-dialog/src/index.tsx
+++ b/packages/ui-dialog/src/index.tsx
@@ -24,12 +24,21 @@ export const innerDialogVariants = cva("flex items-center justify-center", {
     },
 })
 
-export const Modal = forwardRef<HTMLDialogElement, DialogProps<typeof innerDialogVariants>>(({ className, children, ...props }, ref) => {
-    return (
-        <dialog className={merge("w-full min-h-screen max-w-none max-h-none items-center justify-center relative inset-0 bg-transparent backdrop:bg-dialog open:flex", className)} ref={ref} {...props}>
-            {children}
-        </dialog>
-    )
-})
+export const Modal = forwardRef<HTMLDialogElement, DialogProps<typeof innerDialogVariants>>(
+    ({ className, children, ...props }, ref) => {
+        return (
+            <dialog
+                className={merge(
+                    "w-full min-h-screen max-w-none max-h-none items-center justify-center relative inset-0 bg-transparent backdrop:bg-dialog open:flex",
+                    className
+                )}
+                ref={ref}
+                {...props}
+            >
+                {children}
+            </dialog>
+        )
+    }
+)
 
 Modal.displayName = "Dialog"

--- a/packages/ui-form/src/form.stories.tsx
+++ b/packages/ui-form/src/form.stories.tsx
@@ -25,7 +25,10 @@ const meta: Meta = {
                 setIsDark(document.querySelector("html")?.classList?.contains("dark") ?? false)
             }, [])
             return (
-                <div className="w-full h-full mx-auto flex items-center justify-center absolute inset-0 data-[dark='true']:bg-black" data-dark={isDark}>
+                <div
+                    className="w-full h-full mx-auto flex items-center justify-center absolute inset-0 data-[dark='true']:bg-black"
+                    data-dark={isDark}
+                >
                     <div className="w-full dark:text-white">
                         <Button className="absolute top-[4%] left-[4%]" onClick={handleToggleTheme}>
                             Theme

--- a/packages/ui-form/src/index.tsx
+++ b/packages/ui-form/src/index.tsx
@@ -26,12 +26,14 @@ export const formVariants = cva("mx-auto flex items-center flex-col relative", {
     },
 })
 
-export const Form = forwardRef<HTMLFormElement, FormProps<typeof formVariants>>(({ className, variant, size, children, ...props }, ref) => {
-    return (
-        <form className={merge(formVariants({ className, variant, size }))} ref={ref} {...props}>
-            {children}
-        </form>
-    )
-})
+export const Form = forwardRef<HTMLFormElement, FormProps<typeof formVariants>>(
+    ({ className, variant, size, children, ...props }, ref) => {
+        return (
+            <form className={merge(formVariants({ className, variant, size }))} ref={ref} {...props}>
+                {children}
+            </form>
+        )
+    }
+)
 
 Form.displayName = "Form"

--- a/packages/ui-input/src/index.tsx
+++ b/packages/ui-input/src/index.tsx
@@ -4,38 +4,50 @@ import { cva, type VariantProps } from "class-variance-authority"
 
 export type InputProps<T extends ArgsFunction> = VariantProps<T> & ComponentProps<"input", "size">
 
-export const inputVariants = cva("text-primary border bg-input-background focus-visible:outline-none disabled:cursor-not-allowed disabled:text-disabled disabled:border-disabled disabled:bg-disabled", {
-    variants: {
-        size: {
-            sm: "h-8 indent-2 text-sm rounded-md",
-            base: "h-9 indent-3 rounded-lg",
-            md: "h-10 indent-3 rounded-lg",
-            lg: "h-11 indent-4 text-lg rounded-xl",
+export const inputVariants = cva(
+    "text-primary border bg-input-background focus-visible:outline-none disabled:cursor-not-allowed disabled:text-disabled disabled:border-disabled disabled:bg-disabled",
+    {
+        variants: {
+            size: {
+                sm: "h-8 indent-2 text-sm rounded-md",
+                base: "h-9 indent-3 rounded-lg",
+                md: "h-10 indent-3 rounded-lg",
+                lg: "h-11 indent-4 text-lg rounded-xl",
+            },
+            variant: {
+                base: "caret-primary border-input focus-visible:ring-1 focus-visible:border-input focus-visible:ring-input",
+                line: "border-0 border-b border-input rounded-none",
+                sensitive:
+                    "focus-visible:ring-1 focus-visible:border-primary focus-visible:ring-primary usinvalid:text-rose-300 usinvalid:placeholder-rose-400  usinvalid:border-rose-400 usinvalid:focus-within:ring-rose-400 usvalid:text-green-400 usvalid:border-green-400 usvalid:focus-within:ring-green-400 input-empty:usinvalid:border-inherit input-empty:usinvalid:placeholder-slate-300 input-empty:usinvalid:caret-slate-600 input-empty:usinvalid:focus-within:border-slate-700 input-empty:usinvalid:focus-within:ring-slate-700",
+            },
+            fullWidth: {
+                true: "w-full",
+                false: "w-fit",
+            },
+            fullRounded: {
+                true: "rounded-full",
+            },
         },
-        variant: {
-            base: "caret-primary border-input focus-visible:ring-1 focus-visible:border-input focus-visible:ring-input",
-            line: "border-0 border-b border-input rounded-none",
-            sensitive:
-                "focus-visible:ring-1 focus-visible:border-primary focus-visible:ring-primary usinvalid:text-rose-300 usinvalid:placeholder-rose-400  usinvalid:border-rose-400 usinvalid:focus-within:ring-rose-400 usvalid:text-green-400 usvalid:border-green-400 usvalid:focus-within:ring-green-400 input-empty:usinvalid:border-inherit input-empty:usinvalid:placeholder-slate-300 input-empty:usinvalid:caret-slate-600 input-empty:usinvalid:focus-within:border-slate-700 input-empty:usinvalid:focus-within:ring-slate-700",
+        defaultVariants: {
+            variant: "base",
+            size: "base",
+            fullWidth: true,
+            fullRounded: false,
         },
-        fullWidth: {
-            true: "w-full",
-            false: "w-fit",
-        },
-        fullRounded: {
-            true: "rounded-full",
-        },
-    },
-    defaultVariants: {
-        variant: "base",
-        size: "base",
-        fullWidth: true,
-        fullRounded: false,
-    },
-})
+    }
+)
 
-export const Input = forwardRef<HTMLInputElement, InputProps<typeof inputVariants>>(({ className, variant, size, fullWidth, fullRounded, type, ...props }, ref) => {
-    return <input className={merge(inputVariants({ className, variant, size, fullWidth, fullRounded }))} type={type} ref={ref} {...props} />
-})
+export const Input = forwardRef<HTMLInputElement, InputProps<typeof inputVariants>>(
+    ({ className, variant, size, fullWidth, fullRounded, type, ...props }, ref) => {
+        return (
+            <input
+                className={merge(inputVariants({ className, variant, size, fullWidth, fullRounded }))}
+                type={type}
+                ref={ref}
+                {...props}
+            />
+        )
+    }
+)
 
 Input.displayName = "Input"

--- a/packages/ui-input/src/input.stories.tsx
+++ b/packages/ui-input/src/input.stories.tsx
@@ -27,7 +27,10 @@ const meta: Meta = {
                 setIsDark(document.querySelector("html")?.classList?.contains("dark") ?? false)
             }, [])
             return (
-                <div className="w-full h-full mx-auto flex items-center justify-center absolute inset-0 data-[dark='true']:bg-black" data-dark={isDark}>
+                <div
+                    className="w-full h-full mx-auto flex items-center justify-center absolute inset-0 data-[dark='true']:bg-black"
+                    data-dark={isDark}
+                >
                     <div className="w-full dark:text-white">
                         <Button className="absolute top-[4%] left-[4%]" onClick={handleToggleTheme}>
                             Theme

--- a/packages/ui-label/src/index.tsx
+++ b/packages/ui-label/src/index.tsx
@@ -28,13 +28,15 @@ export const labelVariants = cva("font-medium text-left relative leading-none", 
     },
 })
 
-export const Label = forwardRef<HTMLLabelElement, LabelProps<typeof labelVariants>>(({ className, variant, size, children, asChild, ...props }, ref) => {
-    const SlotComponent = asChild ? Slot : "label"
-    return (
-        <SlotComponent className={merge(labelVariants({ className, variant, size }))} ref={ref} {...props}>
-            {children}
-        </SlotComponent>
-    )
-})
+export const Label = forwardRef<HTMLLabelElement, LabelProps<typeof labelVariants>>(
+    ({ className, variant, size, children, asChild, ...props }, ref) => {
+        const SlotComponent = asChild ? Slot : "label"
+        return (
+            <SlotComponent className={merge(labelVariants({ className, variant, size }))} ref={ref} {...props}>
+                {children}
+            </SlotComponent>
+        )
+    }
+)
 
 Label.displayName = "Label"

--- a/packages/ui-label/src/label.stories.tsx
+++ b/packages/ui-label/src/label.stories.tsx
@@ -28,7 +28,10 @@ const meta: Meta = {
                 setIsDark(document.querySelector("html")?.classList?.contains("dark") ?? false)
             }, [])
             return (
-                <div className="w-full h-full mx-auto flex items-center justify-center absolute inset-0 data-[dark='true']:bg-black" data-dark={isDark}>
+                <div
+                    className="w-full h-full mx-auto flex items-center justify-center absolute inset-0 data-[dark='true']:bg-black"
+                    data-dark={isDark}
+                >
                     <div className="w-full dark:text-white">
                         <Button className="absolute top-[4%] left-[4%]" onClick={handleToggleTheme}>
                             Theme
@@ -68,7 +71,14 @@ export const Error: Story = {
     render: () => (
         <Label>
             <Label htmlFor="error-story">Name</Label>
-            <Input className="peer" variant="sensitive" placeholder="John@doe.com" type="email" id="error-story" required />
+            <Input
+                className="peer"
+                variant="sensitive"
+                placeholder="John@doe.com"
+                type="email"
+                id="error-story"
+                required
+            />
             <Label className="right-0" variant="error" size="sm" asChild>
                 <span>Invalid email address</span>
             </Label>

--- a/packages/ui-radio-group/src/index.tsx
+++ b/packages/ui-radio-group/src/index.tsx
@@ -17,24 +17,31 @@ export const radioGroupVariants = cva("flex", {
     },
 })
 
-export const RadioGroup = forwardRef<HTMLFieldSetElement, RadioGroupProps<typeof radioGroupVariants>>(({ className, variant, name, defaultValue, children, ...props }, ref) => {
-    // @ts-ignore
-    const reference = useRef<HTMLFieldSetElement>(ref?.current)
+export const RadioGroup = forwardRef<HTMLFieldSetElement, RadioGroupProps<typeof radioGroupVariants>>(
+    ({ className, variant, name, defaultValue, children, ...props }, ref) => {
+        // @ts-ignore
+        const reference = useRef<HTMLFieldSetElement>(ref?.current)
 
-    useEffect(() => {
-        if (!reference.current) return
-        const radioButtons = reference.current.querySelectorAll("input[type=radio]")
-        radioButtons.forEach((radio) => {
-            if (radio.getAttribute("value") === defaultValue) {
-                radio.setAttribute("checked", "checked")
-            }
-            radio.setAttribute("name", name ?? "default-radio-group")
-        })
-    }, [])
+        useEffect(() => {
+            if (!reference.current) return
+            const radioButtons = reference.current.querySelectorAll("input[type=radio]")
+            radioButtons.forEach((radio) => {
+                if (radio.getAttribute("value") === defaultValue) {
+                    radio.setAttribute("checked", "checked")
+                }
+                radio.setAttribute("name", name ?? "default-radio-group")
+            })
+        }, [])
 
-    return (
-        <fieldset className={merge(radioGroupVariants({ className, variant }))} defaultValue={defaultValue} ref={reference} {...props}>
-            {children}
-        </fieldset>
-    )
-})
+        return (
+            <fieldset
+                className={merge(radioGroupVariants({ className, variant }))}
+                defaultValue={defaultValue}
+                ref={reference}
+                {...props}
+            >
+                {children}
+            </fieldset>
+        )
+    }
+)

--- a/packages/ui-radio-group/src/radio-group.stories.tsx
+++ b/packages/ui-radio-group/src/radio-group.stories.tsx
@@ -25,7 +25,10 @@ const meta: Meta = {
                 setIsDark(document.querySelector("html")?.classList?.contains("dark") ?? false)
             }, [])
             return (
-                <div className="w-full h-full mx-auto flex items-center justify-center absolute inset-0 data-[dark='true']:bg-black" data-dark={isDark}>
+                <div
+                    className="w-full h-full mx-auto flex items-center justify-center absolute inset-0 data-[dark='true']:bg-black"
+                    data-dark={isDark}
+                >
                     <div className="w-full dark:text-white">
                         <Button className="absolute top-[4%] left-[4%]" onClick={handleToggleTheme}>
                             Theme

--- a/packages/ui-radio/src/index.tsx
+++ b/packages/ui-radio/src/index.tsx
@@ -48,13 +48,21 @@ const internalVariants = cva("block absolute rounded-full", {
     },
 })
 
-export const Radio = forwardRef<HTMLInputElement, RadioProps<typeof radioVariants & typeof internalVariants>>(({ className, size, color, name, ...props }, ref) => {
-    return (
-        <label className="w-min inline-flex items-center justify-center relative" htmlFor={name}>
-            <input className={merge(radioVariants({ className, size, color }))} type="radio" name={name} ref={ref} {...props} />
-            <span className={internalVariants({ size, color })} />
-        </label>
-    )
-})
+export const Radio = forwardRef<HTMLInputElement, RadioProps<typeof radioVariants & typeof internalVariants>>(
+    ({ className, size, color, name, ...props }, ref) => {
+        return (
+            <label className="w-min inline-flex items-center justify-center relative" htmlFor={name}>
+                <input
+                    className={merge(radioVariants({ className, size, color }))}
+                    type="radio"
+                    name={name}
+                    ref={ref}
+                    {...props}
+                />
+                <span className={internalVariants({ size, color })} />
+            </label>
+        )
+    }
+)
 
 Radio.displayName = "Radio"

--- a/packages/ui-radio/src/radio.stories.tsx
+++ b/packages/ui-radio/src/radio.stories.tsx
@@ -29,7 +29,10 @@ const meta: Meta = {
                 setIsDark(document.querySelector("html")?.classList?.contains("dark") ?? false)
             }, [])
             return (
-                <div className="w-full h-full mx-auto flex items-center justify-center absolute inset-0 data-[dark='true']:bg-black" data-dark={isDark}>
+                <div
+                    className="w-full h-full mx-auto flex items-center justify-center absolute inset-0 data-[dark='true']:bg-black"
+                    data-dark={isDark}
+                >
                     <div className="w-full dark:text-white">
                         <Button className="absolute top-[4%] left-[4%]" onClick={handleToggleTheme}>
                             Theme

--- a/packages/ui-submit/src/index.tsx
+++ b/packages/ui-submit/src/index.tsx
@@ -6,40 +6,72 @@ interface InternalSubmitProps {
     pending?: string
 }
 
-export type SubmitProps<T extends ArgsFunction> = VariantProps<T> & ComponentProps<"input", "type" | "size"> & InternalSubmitProps
+export type SubmitProps<T extends ArgsFunction> = VariantProps<T> &
+    ComponentProps<"input", "type" | "size"> &
+    InternalSubmitProps
 
-export const submitVariants = cva("font-medium border focus-visible:[outline-style:solid] focus-visible:outline-2 focus-visible:outline-offset-2 hover:cursor-pointer disabled:hover:cursor-progress", {
-    variants: {
-        variant: {
-            base: "text-color-100 border-primary bg-primary focus-visible:outline-primary disabled:bg-primary-hover",
-            secondary: "text-color-200 border-secondary bg-secondary focus-visible:outline-secondary disabled:bg-secondary-hover",
-            inverted: "text-color-100 border-primary bg-primary focus-visible:outline-primary disabled:bg-primary-hover invert",
+export const submitVariants = cva(
+    "font-medium border focus-visible:[outline-style:solid] focus-visible:outline-2 focus-visible:outline-offset-2 hover:cursor-pointer disabled:hover:cursor-progress",
+    {
+        variants: {
+            variant: {
+                base: "text-color-100 border-primary bg-primary focus-visible:outline-primary disabled:bg-primary-hover",
+                secondary:
+                    "text-color-200 border-secondary bg-secondary focus-visible:outline-secondary disabled:bg-secondary-hover",
+                inverted:
+                    "text-color-100 border-primary bg-primary focus-visible:outline-primary disabled:bg-primary-hover invert",
+            },
+            size: {
+                sm: "h-9 px-3 text-sm rounded",
+                base: "h-10 px-4 text-base rounded-md",
+                md: "h-10 px-5 text-base rounded-md",
+                lg: "h-11 px-6 text-lg rounded-lg",
+            },
+            fullWidth: {
+                true: "w-full",
+                false: "w-fit",
+            },
+            fullRounded: {
+                true: "rounded-full",
+            },
         },
-        size: {
-            sm: "h-9 px-3 text-sm rounded",
-            base: "h-10 px-4 text-base rounded-md",
-            md: "h-10 px-5 text-base rounded-md",
-            lg: "h-11 px-6 text-lg rounded-lg",
+        defaultVariants: {
+            variant: "base",
+            size: "base",
+            fullWidth: false,
+            fullRounded: false,
         },
-        fullWidth: {
-            true: "w-full",
-            false: "w-fit",
-        },
-        fullRounded: {
-            true: "rounded-full",
-        },
-    },
-    defaultVariants: {
-        variant: "base",
-        size: "base",
-        fullWidth: false,
-        fullRounded: false,
-    },
-})
+    }
+)
 
-export const Submit = forwardRef<HTMLInputElement, SubmitProps<typeof submitVariants>>(({ className, variant, size, fullWidth, fullRounded, value = "Submit", pending = "Submitting...", disabled, ...props }, ref) => {
-    const message = disabled ? pending : value
-    return <input className={merge(submitVariants({ className, variant, size, fullWidth, fullRounded }))} type="submit" value={message} disabled={disabled} aria-disabled={disabled} ref={ref} {...props} />
-})
+export const Submit = forwardRef<HTMLInputElement, SubmitProps<typeof submitVariants>>(
+    (
+        {
+            className,
+            variant,
+            size,
+            fullWidth,
+            fullRounded,
+            value = "Submit",
+            pending = "Submitting...",
+            disabled,
+            ...props
+        },
+        ref
+    ) => {
+        const message = disabled ? pending : value
+        return (
+            <input
+                className={merge(submitVariants({ className, variant, size, fullWidth, fullRounded }))}
+                type="submit"
+                value={message}
+                disabled={disabled}
+                aria-disabled={disabled}
+                ref={ref}
+                {...props}
+            />
+        )
+    }
+)
 
 Submit.displayName = "Input"

--- a/packages/ui-submit/src/submit.stories.tsx
+++ b/packages/ui-submit/src/submit.stories.tsx
@@ -28,7 +28,10 @@ const meta: Meta = {
                 setIsDark(document.querySelector("html")?.classList?.contains("dark") ?? false)
             }, [])
             return (
-                <div className="w-full h-full mx-auto flex items-center justify-center absolute inset-0 data-[dark='true']:bg-black" data-dark={isDark}>
+                <div
+                    className="w-full h-full mx-auto flex items-center justify-center absolute inset-0 data-[dark='true']:bg-black"
+                    data-dark={isDark}
+                >
                     <div className="w-full dark:text-white">
                         <Button className="absolute top-[4%] left-[4%]" onClick={handleToggleTheme}>
                             Theme

--- a/packages/ui-template/src/index.stories.tsx
+++ b/packages/ui-template/src/index.stories.tsx
@@ -28,7 +28,10 @@ const meta: Meta = {
             }, [])
 
             return (
-                <div className="w-full h-full mx-auto flex items-center justify-center absolute inset-0 data-[dark='true']:bg-black" data-dark={isDark}>
+                <div
+                    className="w-full h-full mx-auto flex items-center justify-center absolute inset-0 data-[dark='true']:bg-black"
+                    data-dark={isDark}
+                >
                     <div className="w-full dark:text-white">
                         <Button className="absolute top-[4%] left-[4%]" onClick={handleToggleTheme}>
                             Theme


### PR DESCRIPTION
## Description
This is pull request removes the override options for `.tsx` files, which previously had a `printWidth` of 300. The wide setting caused uncomfortable horizontal scrolling. After applying the changes, the `format` script was executed to format the files using the updated configuration.

## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
