### PR TITLE
chore(turbo): add `clean:turbo` script in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "test:e2e:ui": "playwright test",
     "test:e2e:report": "playwright show-report",
     "clean": "turbo run clean --parallel",
-    "clean:build": "turbo run clean:build --parallel",
-    "clean:modules": "turbo run clean:modules --parallel"
+    "clean:dist": "turbo run clean:dist --parallel",
+    "clean:modules": "turbo run clean:modules --parallel",
+    "clean:turbo": "turbo run clean:turbo --parallel"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-button/package.json
+++ b/packages/ui-button/package.json
@@ -8,9 +8,10 @@
     "build": "tsup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "clean": "pnpm clean:build && pnpm clean:modules",
-    "clean:build": "rm -rf dist",
-    "clean:modules": "rm -rf node_modules"
+    "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
+    "clean:dist": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules",
+    "clean:turbo": "rm -rf .turbo"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-checkbox/package.json
+++ b/packages/ui-checkbox/package.json
@@ -9,9 +9,10 @@
     "build": "tsup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "clean": "pnpm clean:build && pnpm clean:modules",
-    "clean:build": "rm -rf dist",
-    "clean:modules": "rm -rf node_modules"
+    "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
+    "clean:dist": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules",
+    "clean:turbo": "rm -rf .turbo"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -8,9 +8,10 @@
     "build": "tsup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "clean": "pnpm clean:build && pnpm clean:modules",
-    "clean:build": "rm -rf dist",
-    "clean:modules": "rm -rf node_modules"
+    "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
+    "clean:dist": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules",
+    "clean:turbo": "rm -rf .turbo"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-dialog/package.json
+++ b/packages/ui-dialog/package.json
@@ -9,9 +9,10 @@
     "build": "tsup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "clean": "pnpm clean:build && pnpm clean:modules",
-    "clean:build": "rm -rf dist",
-    "clean:modules": "rm -rf node_modules"
+    "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
+    "clean:dist": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules",
+    "clean:turbo": "rm -rf .turbo"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-form/package.json
+++ b/packages/ui-form/package.json
@@ -9,9 +9,10 @@
     "build": "tsup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "clean": "pnpm clean:build && pnpm clean:modules",
-    "clean:build": "rm -rf dist",
-    "clean:modules": "rm -rf node_modules"
+    "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
+    "clean:dist": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules",
+    "clean:turbo": "rm -rf .turbo"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-input/package.json
+++ b/packages/ui-input/package.json
@@ -9,9 +9,10 @@
     "build": "tsup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "clean": "pnpm clean:build && pnpm clean:modules",
-    "clean:build": "rm -rf dist",
-    "clean:modules": "rm -rf node_modules"
+    "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
+    "clean:dist": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules",
+    "clean:turbo": "rm -rf .turbo"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-label/package.json
+++ b/packages/ui-label/package.json
@@ -9,9 +9,10 @@
     "build": "tsup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "clean": "pnpm clean:build && pnpm clean:modules",
-    "clean:build": "rm -rf dist",
-    "clean:modules": "rm -rf node_modules"
+    "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
+    "clean:dist": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules",
+    "clean:turbo": "rm -rf .turbo"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-radio-group/package.json
+++ b/packages/ui-radio-group/package.json
@@ -9,9 +9,10 @@
     "build": "tsup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "clean": "pnpm clean:build && pnpm clean:modules",
-    "clean:build": "rm -rf dist",
-    "clean:modules": "rm -rf node_modules"
+    "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
+    "clean:dist": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules",
+    "clean:turbo": "rm -rf .turbo"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-radio/package.json
+++ b/packages/ui-radio/package.json
@@ -9,9 +9,10 @@
     "build": "tsup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "clean": "pnpm clean:build && pnpm clean:modules",
-    "clean:build": "rm -rf dist",
-    "clean:modules": "rm -rf node_modules"
+    "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
+    "clean:dist": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules",
+    "clean:turbo": "rm -rf .turbo"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-submit/package.json
+++ b/packages/ui-submit/package.json
@@ -9,9 +9,10 @@
     "build": "tsup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "clean": "pnpm clean:build && pnpm clean:modules",
-    "clean:build": "rm -rf dist",
-    "clean:modules": "rm -rf node_modules"
+    "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
+    "clean:dist": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules",
+    "clean:turbo": "rm -rf .turbo"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-template/package.json
+++ b/packages/ui-template/package.json
@@ -9,9 +9,10 @@
     "build": "tsup",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "clean": "pnpm clean:build && pnpm clean:modules",
-    "clean:build": "rm -rf dist",
-    "clean:modules": "rm -rf node_modules"
+    "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
+    "clean:dist": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules",
+    "clean:turbo": "rm -rf .turbo"
   },
   "repository": {
     "type": "git",

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": ["tsconfig.json"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -16,12 +15,17 @@
       "cache": false,
       "inputs": ["dist", "node_modules"]
     },
-    "clean:build": {
+    "clean:dist": {
       "cache": false
     },
     "clean:modules": {
       "cache": false
+    },
+    "clean:turbo": {
+      "cache": false
     }
   },
-  "cacheDir": ".turbo/cache"
+  "ui": "tui",
+  "cacheDir": ".turbo/cache",
+  "globalDependencies": ["tsconfig.json"]
 }


### PR DESCRIPTION
## Description

This pull request introduces a new script called `clean:turbo` to the `package.json` file. This script will be useful for switching between branches, such as from `master` to `beta` and vice versa. The addition of this script aims to reduce configuration time for maintainers and contributors when moving between branches.

## Changes

- Added `clean:turbo` script: This script helps streamline the process of changing branches by cleaning up the necessary files.
- Updated `clean:build` script to `clean:dist`: This update enhances the readability of the code and provides a better description of the script's behavior.

## Benefits

- Improved efficiency for maintainers and contributors when switching branches.
- Enhanced code readability and clearer script descriptions.

## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
