### PR TITLE
chore(stories): add `args`, `argTypes` and block docs in stories

### DIFF
--- a/packages/ui-button/src/button.stories.tsx
+++ b/packages/ui-button/src/button.stories.tsx
@@ -1,15 +1,43 @@
-import type { Meta, StoryObj } from "@storybook/react"
+import type { Meta, StoryObj, ArgTypes } from "@storybook/react"
 import { Button } from "./index.jsx"
 import { decorator } from "@halvaradop/ui-utils/decorator"
 import { Title, Canvas, Subtitle, Controls } from "@storybook/blocks"
+
+const variant: ArgTypes["variant"] = {
+    control: "select",
+    description: "The variant of the button",
+    options: ["base", "secondary", "ghost", "link", "destructive", "outline", "plain"],
+    table: {
+        type: {
+            summary: "base | secondary | ghost | link | destructive | outline | plain",
+        },
+        defaultValue: {
+            summary: "base",
+        },
+    },
+}
+
+const size: ArgTypes["size"] = {
+    control: "select",
+    description: "Size of the button",
+    options: ["sm", "base", "md", "lg"],
+    table: {
+        type: {
+            summary: "sm | base | md | lg",
+        },
+        defaultValue: {
+            summary: "base",
+        },
+    },
+}
 
 const meta: Meta = {
     title: "ui-button",
     tags: ["autodocs"],
     component: Button,
     args: {
-        children: "Button",
-        variant: "base",
+        children: "Click me!",
+        fullRounded: false,
     },
     argTypes: {
         children: {
@@ -20,32 +48,6 @@ const meta: Meta = {
             table: {
                 type: {
                     summary: "ReactNode | String",
-                },
-            },
-        },
-        variant: {
-            control: "select",
-            description: "The variant of the button",
-            options: ["base", "secondary", "ghost", "link", "destructive", "outline", "plain"],
-            table: {
-                type: {
-                    summary: "base | secondary | ghost | link | destructive | outline | plain",
-                },
-                defaultValue: {
-                    summary: "base",
-                },
-            },
-        },
-        size: {
-            control: "select",
-            description: "Size of the button",
-            options: ["sm", "base", "md", "lg"],
-            table: {
-                type: {
-                    summary: "sm | base | md | lg",
-                },
-                defaultValue: {
-                    summary: "base",
                 },
             },
         },
@@ -65,7 +67,6 @@ const meta: Meta = {
     parameters: {
         layout: "centered",
         backgrounds: {
-            default: "light",
             grid: true,
         },
         docs: {
@@ -87,6 +88,11 @@ type Story = StoryObj<typeof meta>
 export const Base: Story = {
     args: {
         size: "base",
+        variant: "base",
+    },
+    argTypes: {
+        size,
+        variant,
     },
     parameters: {
         skipDecorator: true,
@@ -94,66 +100,59 @@ export const Base: Story = {
 }
 
 export const Variants: Story = {
-    render: () => (
-        <>
-            <div>
-                <span className="font-medium">Base</span>
-                <Button variant="base">Click me!</Button>
-            </div>
-            <div>
-                <span className="font-medium">Secondary</span>
-                <Button variant="secondary">Click me!</Button>
-            </div>
-            <div>
-                <span className="font-medium">Ghost</span>
-                <Button variant="ghost">Click me!</Button>
-            </div>
-            <div>
-                <span className="font-medium">Link</span>
-                <Button variant="link">Click me!</Button>
-            </div>
-            <div>
-                <span className="font-medium">Destructive</span>
-                <Button variant="destructive">Click me!</Button>
-            </div>
-            <div>
-                <span className="font-medium">Outline</span>
-                <Button variant="outline">Click me!</Button>
-            </div>
-            <div>
-                <span className="font-medium">Plain</span>
-                <Button variant="plain">Click me!</Button>
-            </div>
-        </>
-    ),
+    args: {
+        size: "base",
+    },
+    argTypes: {
+        size,
+    },
+    render: ({ children, size, fullRounded }) => {
+        const variants = ["base", "secondary", "ghost", "link", "destructive", "outline", "plain"]
+        return (
+            <>
+                {variants.map((variant) => (
+                    <div key={variant}>
+                        <span className="font-medium capitalize">{variant}</span>
+                        <Button variant={variant as any} size={size} fullRounded={fullRounded}>
+                            {children}
+                        </Button>
+                    </div>
+                ))}
+            </>
+        )
+    },
 }
 
 export const Sizes: Story = {
-    render: () => (
-        <>
-            <div>
-                <span className="font-medium">sm</span>
-                <Button size="sm">Click me!</Button>
-            </div>
-            <div>
-                <span className="font-medium">base</span>
-                <Button size="base">Click me!</Button>
-            </div>
-            <div>
-                <span className="font-medium">md</span>
-                <Button size="md">Click me!</Button>
-            </div>
-            <div>
-                <span className="font-medium">lg</span>
-                <Button size="lg">Click me!</Button>
-            </div>
-        </>
-    ),
+    args: {
+        variant: "base",
+    },
+    argTypes: {
+        variant,
+    },
+    render: ({ children, variant, fullRounded }) => {
+        const sizes = ["sm", "base", "md", "lg"]
+        return (
+            <>
+                {sizes.map((size) => (
+                    <div key={size}>
+                        <span className="font-medium capitalize">{size}</span>
+                        <Button size={size as any} variant={variant} fullRounded={fullRounded}>
+                            {children}
+                        </Button>
+                    </div>
+                ))}
+            </>
+        )
+    },
 }
 
 export const AsAnchor: Story = {
-    render: () => (
-        <Button variant="link" asChild>
+    argTypes: {
+        size,
+    },
+    render: (args) => (
+        <Button variant="link" asChild {...args}>
             <a href="">Link</a>
         </Button>
     ),

--- a/packages/ui-button/src/button.stories.tsx
+++ b/packages/ui-button/src/button.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import { Button } from "./index.jsx"
 import { decorator } from "@halvaradop/ui-utils/decorator"
+import { Title, Canvas, Subtitle, Controls } from "@storybook/blocks"
 
 const meta: Meta = {
     title: "ui-button",
@@ -11,9 +12,54 @@ const meta: Meta = {
         variant: "base",
     },
     argTypes: {
+        children: {
+            description: "The content of the Component",
+            control: {
+                type: "text",
+            },
+            table: {
+                type: {
+                    summary: "ReactNode | String",
+                },
+            },
+        },
         variant: {
             control: "select",
+            description: "The variant of the button",
             options: ["base", "secondary", "ghost", "link", "destructive", "outline", "plain"],
+            table: {
+                type: {
+                    summary: "base | secondary | ghost | link | destructive | outline | plain",
+                },
+                defaultValue: {
+                    summary: "base",
+                },
+            },
+        },
+        size: {
+            control: "select",
+            description: "Size of the button",
+            options: ["sm", "base", "md", "lg"],
+            table: {
+                type: {
+                    summary: "sm | base | md | lg",
+                },
+                defaultValue: {
+                    summary: "base",
+                },
+            },
+        },
+        fullRounded: {
+            control: "boolean",
+            description: "Make the button full rounded",
+            table: {
+                type: {
+                    summary: "boolean",
+                },
+                defaultValue: {
+                    summary: "false",
+                },
+            },
         },
     },
     parameters: {
@@ -22,13 +68,30 @@ const meta: Meta = {
             default: "light",
             grid: true,
         },
+        docs: {
+            page: () => (
+                <>
+                    <Title />
+                    <Subtitle>Button Component powered by React & TailwindCSS</Subtitle>
+                    <Canvas />
+                    <Controls />
+                </>
+            ),
+        },
     },
     decorators: [decorator],
 } satisfies Meta<typeof Button>
 
 type Story = StoryObj<typeof meta>
 
-export const Base: Story = {}
+export const Base: Story = {
+    args: {
+        size: "base",
+    },
+    parameters: {
+        skipDecorator: true,
+    },
+}
 
 export const Variants: Story = {
     render: () => (

--- a/packages/ui-checkbox/src/checkbox.stories.tsx
+++ b/packages/ui-checkbox/src/checkbox.stories.tsx
@@ -1,22 +1,83 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import { Checkbox } from "./index.js"
 import { decorator } from "@halvaradop/ui-utils/decorator"
+import { Title, Canvas, Subtitle, Controls } from "@storybook/blocks"
 
 const meta: Meta = {
     title: "ui-checkbox",
     tags: ["autodocs"],
     component: Checkbox,
+    args: {
+        size: "base",
+        color: "green",
+    },
+    argTypes: {
+        size: {
+            control: "select",
+            options: ["sm", "base", "md", "lg"],
+            description: "Size of the checkbox",
+            table: {
+                type: {
+                    summary: "sm | base | md | lg",
+                },
+                defaultValue: {
+                    summary: "base",
+                },
+            },
+        },
+        color: {
+            control: "select",
+            options: ["green", "blue", "red", "yellow", "primary"],
+            description: "Color of the checkbox",
+            table: {
+                type: {
+                    summary: "green | blue | red | yellow | primary",
+                },
+                defaultValue: {
+                    summary: "green",
+                },
+            },
+        },
+        fullRounded: {
+            control: "boolean",
+            description: "Make the checkbox full rounded",
+            table: {
+                type: {
+                    summary: "boolean",
+                },
+                defaultValue: {
+                    summary: "false",
+                },
+            },
+        },
+    },
     parameters: {
         layout: "centered",
         backgrounds: {
             default: "light",
             grid: true,
         },
+        docs: {
+            page: () => (
+                <>
+                    <Title />
+                    <Subtitle>Checkbox component powered by React & TailwindCSS</Subtitle>
+                    <Canvas />
+                    <Controls />
+                </>
+            ),
+        },
     },
     decorators: [decorator],
 } satisfies Meta<typeof Checkbox>
 
 type Story = StoryObj<typeof meta>
+
+export const Base: Story = {
+    parameters: {
+        skipDecorator: true,
+    },
+}
 
 export const Sizes: Story = {
     render: () => (

--- a/packages/ui-checkbox/src/checkbox.stories.tsx
+++ b/packages/ui-checkbox/src/checkbox.stories.tsx
@@ -1,43 +1,44 @@
-import type { Meta, StoryObj } from "@storybook/react"
+import type { ArgTypes, Meta, StoryObj } from "@storybook/react"
 import { Checkbox } from "./index.js"
 import { decorator } from "@halvaradop/ui-utils/decorator"
 import { Title, Canvas, Subtitle, Controls } from "@storybook/blocks"
+
+const size: ArgTypes["size"] = {
+    control: "select",
+    options: ["sm", "base", "md", "lg"],
+    description: "Size of the checkbox",
+    table: {
+        type: {
+            summary: "sm | base | md | lg",
+        },
+        defaultValue: {
+            summary: "base",
+        },
+    },
+}
+
+const color: ArgTypes["color"] = {
+    control: "select",
+    options: ["green", "blue", "red", "yellow", "primary"],
+    description: "Color of the checkbox",
+    table: {
+        type: {
+            summary: "green | blue | red | yellow | primary",
+        },
+        defaultValue: {
+            summary: "green",
+        },
+    },
+}
 
 const meta: Meta = {
     title: "ui-checkbox",
     tags: ["autodocs"],
     component: Checkbox,
     args: {
-        size: "base",
-        color: "green",
+        fullRounded: false,
     },
     argTypes: {
-        size: {
-            control: "select",
-            options: ["sm", "base", "md", "lg"],
-            description: "Size of the checkbox",
-            table: {
-                type: {
-                    summary: "sm | base | md | lg",
-                },
-                defaultValue: {
-                    summary: "base",
-                },
-            },
-        },
-        color: {
-            control: "select",
-            options: ["green", "blue", "red", "yellow", "primary"],
-            description: "Color of the checkbox",
-            table: {
-                type: {
-                    summary: "green | blue | red | yellow | primary",
-                },
-                defaultValue: {
-                    summary: "green",
-                },
-            },
-        },
         fullRounded: {
             control: "boolean",
             description: "Make the checkbox full rounded",
@@ -54,7 +55,6 @@ const meta: Meta = {
     parameters: {
         layout: "centered",
         backgrounds: {
-            default: "light",
             grid: true,
         },
         docs: {
@@ -74,56 +74,76 @@ const meta: Meta = {
 type Story = StoryObj<typeof meta>
 
 export const Base: Story = {
+    args: {
+        size: "base",
+        color: "green",
+    },
+    argTypes: {
+        size,
+        color,
+    },
     parameters: {
         skipDecorator: true,
     },
 }
 
 export const Sizes: Story = {
-    render: () => (
+    args: {
+        color: "green",
+    },
+    argTypes: {
+        color,
+    },
+    render: (args) => (
         <>
             <div>
                 <span className="font-medium">sm</span>
-                <Checkbox size="sm" />
+                <Checkbox size="sm" {...args} />
             </div>
             <div>
                 <span className="font-medium">base</span>
-                <Checkbox size="base" />
+                <Checkbox size="base" {...args} />
             </div>
             <div>
                 <span className="font-medium">mg</span>
-                <Checkbox size="md" />
+                <Checkbox size="md" {...args} />
             </div>
             <div>
                 <span className="font-medium">lg</span>
-                <Checkbox size="lg" />
+                <Checkbox size="lg" {...args} />
             </div>
         </>
     ),
 }
 
 export const Colors: Story = {
-    render: () => (
+    args: {
+        size: "base",
+    },
+    argTypes: {
+        size,
+    },
+    render: (args) => (
         <>
             <div>
                 <span className="font-medium">Green</span>
-                <Checkbox color="green" />
+                <Checkbox color="green" {...args} />
             </div>
             <div>
                 <span className="font-medium">Blue</span>
-                <Checkbox color="blue" />
+                <Checkbox color="blue" {...args} />
             </div>
             <div>
                 <span className="font-medium">Red</span>
-                <Checkbox color="red" />
+                <Checkbox color="red" {...args} />
             </div>
             <div>
                 <span className="font-medium">Yellow</span>
-                <Checkbox color="yellow" />
+                <Checkbox color="yellow" {...args} />
             </div>
             <div>
                 <span className="font-medium">primary</span>
-                <Checkbox color="primary" />
+                <Checkbox color="primary" {...args} />
             </div>
         </>
     ),

--- a/packages/ui-checkbox/src/index.tsx
+++ b/packages/ui-checkbox/src/index.tsx
@@ -46,15 +46,12 @@ export const checkboxVariants = cva(
     }
 )
 
-/**
- * TODO: implement `fullRounded` variant
- */
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps<typeof checkboxVariants>>(
-    ({ className, size, color, name, ...props }, ref) => {
+    ({ className, size, color, fullRounded, name, ...props }, ref) => {
         return (
             <label className="flex items-center justify-center relative" htmlFor={name}>
                 <input
-                    className={merge(checkboxVariants({ className, size, color }), "peer")}
+                    className={merge(checkboxVariants({ className, size, color, fullRounded }), "peer")}
                     type="checkbox"
                     name={name}
                     ref={ref}

--- a/packages/ui-checkbox/src/index.tsx
+++ b/packages/ui-checkbox/src/index.tsx
@@ -2,7 +2,7 @@ import { forwardRef } from "react"
 import { merge, type ComponentProps, type ArgsFunction } from "@halvaradop/ui-core"
 import { cva, type VariantProps } from "class-variance-authority"
 
-export type CheckboxProps<T extends ArgsFunction> = VariantProps<T> & ComponentProps<"input", "type" | "size">
+export type CheckboxProps<T extends ArgsFunction> = ComponentProps<"input", "type" | "size"> & VariantProps<T>
 
 const internalVariants = cva("hidden absolute peer-checked:block", {
     variants: {
@@ -46,6 +46,9 @@ export const checkboxVariants = cva(
     }
 )
 
+/**
+ * TODO: implement `fullRounded` variant
+ */
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps<typeof checkboxVariants>>(
     ({ className, size, color, name, ...props }, ref) => {
         return (

--- a/packages/ui-dialog/src/dialog.stories.tsx
+++ b/packages/ui-dialog/src/dialog.stories.tsx
@@ -5,17 +5,45 @@ import { Button } from "../../ui-button/src/index.js"
 import { decorator } from "@halvaradop/ui-utils/decorator"
 import { Title, Canvas, Subtitle, Controls } from "@storybook/blocks"
 
-/**
- * TODO: Implement Documentation
- */
 const meta: Meta = {
     title: "ui-dialog",
     tags: ["autodocs"],
     component: Modal,
+    args: {
+        size: "base",
+        variant: "base",
+    },
+    argTypes: {
+        size: {
+            control: "select",
+            options: ["sm", "base", "md", "lg"],
+            description: "Size of the dialog",
+            table: {
+                type: {
+                    summary: "sm | base | md | lg",
+                },
+                defaultValue: {
+                    summary: "base",
+                },
+            },
+        },
+        variant: {
+            control: "select",
+            options: ["base", "inner", "fixed"],
+            description: "Variant of the dialog",
+            table: {
+                type: {
+                    summary: "base | inner | fixed",
+                },
+                defaultValue: {
+                    summary: "base",
+                },
+            },
+        },
+    },
     parameters: {
         layout: "centered",
         backgrounds: {
-            default: "light",
             grid: true,
         },
         docs: {
@@ -34,75 +62,35 @@ const meta: Meta = {
 
 type Story = StoryObj<typeof meta>
 
-interface DialogStoryProps {
-    size?: "sm" | "md" | "lg"
-    variant?: "inner" | "fixed"
-}
-
-const DialogStory = ({ size, variant }: DialogStoryProps) => {
-    const modalRef = useRef<HTMLDialogElement>(null)
-
-    const handleToggleModal = (isOpen: boolean): void => {
-        if (isOpen) {
-            modalRef.current?.showModal()
-        } else {
-            modalRef.current?.close()
-        }
-    }
-
-    return (
-        <>
-            <Button onClick={() => handleToggleModal(true)}>Open</Button>
-            <Modal ref={modalRef}>
-                <div className={innerDialogVariants({ size, variant })}>
-                    <div>Modal content</div>
-                    <Button className="mt-4" onClick={() => handleToggleModal(false)}>
-                        Close
-                    </Button>
-                </div>
-            </Modal>
-        </>
-    )
-}
-
 export const Base: Story = {
     parameters: {
-        skipDectorator: true,
+        skipDecorator: true,
     },
-}
+    render: ({ size, variant }) => {
+        const modalRef = useRef<HTMLDialogElement>(null)
 
-export const Variants: Story = {
-    render: () => (
-        <>
-            <div>
-                <span className="font-medium">inner</span>
-                <DialogStory variant="inner" />
-            </div>
-            <div>
-                <span className="font-medium">fixed</span>
-                <DialogStory variant="fixed" />
-            </div>
-        </>
-    ),
-}
+        const handleToggleModal = (isOpen: boolean): void => {
+            if (isOpen) {
+                modalRef.current?.showModal()
+            } else {
+                modalRef.current?.close()
+            }
+        }
 
-export const Sizes: Story = {
-    render: () => (
-        <>
-            <div>
-                <span className="font-medium">sm</span>
-                <DialogStory size="sm" />
-            </div>
-            <div>
-                <span className="font-medium">md</span>
-                <DialogStory size="md" />
-            </div>
-            <div>
-                <span className="font-medium">lg</span>
-                <DialogStory size="lg" />
-            </div>
-        </>
-    ),
+        return (
+            <>
+                <Button onClick={() => handleToggleModal(true)}>Open</Button>
+                <Modal ref={modalRef}>
+                    <div className={innerDialogVariants({ size, variant })}>
+                        <div>Modal content</div>
+                        <Button className="mt-4" onClick={() => handleToggleModal(false)}>
+                            Close
+                        </Button>
+                    </div>
+                </Modal>
+            </>
+        )
+    },
 }
 
 export default meta

--- a/packages/ui-dialog/src/dialog.stories.tsx
+++ b/packages/ui-dialog/src/dialog.stories.tsx
@@ -3,7 +3,11 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { Modal, innerDialogVariants } from "./index.js"
 import { Button } from "../../ui-button/src/index.js"
 import { decorator } from "@halvaradop/ui-utils/decorator"
+import { Title, Canvas, Subtitle, Controls } from "@storybook/blocks"
 
+/**
+ * TODO: Implement Documentation
+ */
 const meta: Meta = {
     title: "ui-dialog",
     tags: ["autodocs"],
@@ -13,6 +17,16 @@ const meta: Meta = {
         backgrounds: {
             default: "light",
             grid: true,
+        },
+        docs: {
+            page: () => (
+                <>
+                    <Title />
+                    <Subtitle>Dialog component powered by React & TailwindCSS</Subtitle>
+                    <Canvas />
+                    <Controls />
+                </>
+            ),
         },
     },
     decorators: [decorator],
@@ -49,6 +63,12 @@ const DialogStory = ({ size, variant }: DialogStoryProps) => {
             </Modal>
         </>
     )
+}
+
+export const Base: Story = {
+    parameters: {
+        skipDectorator: true,
+    },
 }
 
 export const Variants: Story = {

--- a/packages/ui-form/src/form.stories.tsx
+++ b/packages/ui-form/src/form.stories.tsx
@@ -3,13 +3,56 @@ import { Form } from "./index.js"
 import { Input } from "../../ui-input/src/index.js"
 import { Label } from "../../ui-label/src/index.js"
 import { decorator } from "@halvaradop/ui-utils/decorator"
+import { Title, Canvas, Subtitle, Controls } from "@storybook/blocks"
 
 const meta: Meta = {
     title: "ui-form",
     tags: ["autodocs"],
     component: Form,
+    args: {
+        variant: "base",
+        size: "base",
+    },
+    argTypes: {
+        variant: {
+            control: "select",
+            options: ["base", "outline", "inner", "ghost"],
+            description: "Variant of the form",
+            table: {
+                type: {
+                    summary: "base | outline | inner | ghost",
+                },
+                defaultValue: {
+                    summary: "base",
+                },
+            },
+        },
+        size: {
+            control: "select",
+            options: ["sm", "base", "md", "lg", "full"],
+            description: "Size of the form",
+            table: {
+                type: {
+                    summary: "sm | base | md | lg | full",
+                },
+                defaultValue: {
+                    summary: "base",
+                },
+            },
+        },
+    },
     parameters: {
         layout: "centered",
+        docs: {
+            page: () => (
+                <>
+                    <Title />
+                    <Subtitle>Form component powered by React & TailwindCSS</Subtitle>
+                    <Canvas />
+                    <Controls />
+                </>
+            ),
+        },
     },
     decorators: [decorator],
 } satisfies Meta<typeof Form>
@@ -30,6 +73,13 @@ const Template = ({ ...props }: Omit<Parameters<typeof Form>[0], "children">) =>
 )
 
 export const Base: Story = {
+    parameters: {
+        skipDecorator: true,
+    },
+    render: (args) => <Template {...args} />,
+}
+
+export const Default: Story = {
     render: () => <Template />,
 }
 

--- a/packages/ui-form/src/form.stories.tsx
+++ b/packages/ui-form/src/form.stories.tsx
@@ -59,52 +59,22 @@ const meta: Meta = {
 
 type Story = StoryObj<typeof meta>
 
-const Template = ({ ...props }: Omit<Parameters<typeof Form>[0], "children">) => (
-    <Form {...props}>
-        <Label>
-            Username
-            <Input />
-        </Label>
-        <Label>
-            Password
-            <Input />
-        </Label>
-    </Form>
-)
-
 export const Base: Story = {
     parameters: {
         skipDecorator: true,
     },
-    render: (args) => <Template {...args} />,
-}
-
-export const Default: Story = {
-    render: () => <Template />,
-}
-
-export const Outline: Story = {
-    render: () => <Template variant="outline" />,
-}
-
-export const Inner: Story = {
-    render: () => <Template variant="inner" />,
-}
-
-export const Ghost: Story = {
-    render: () => <Template variant="ghost" />,
-}
-
-export const Small: Story = {
-    render: () => <Template size="sm" />,
-}
-
-export const Medium: Story = {
-    render: () => <Template size="md" />,
-}
-
-export const Large: Story = {
-    render: () => <Template size="lg" />,
+    render: ({ size, variant }) => (
+        <Form size={size} variant={variant}>
+            <Label>
+                Username
+                <Input />
+            </Label>
+            <Label>
+                Password
+                <Input />
+            </Label>
+        </Form>
+    ),
 }
 
 export default meta

--- a/packages/ui-input/src/input.stories.tsx
+++ b/packages/ui-input/src/input.stories.tsx
@@ -1,45 +1,46 @@
 import { Input } from "./index.jsx"
-import type { Meta, StoryObj } from "@storybook/react"
+import type { ArgTypes, Meta, StoryObj } from "@storybook/react"
 import { decorator } from "@halvaradop/ui-utils/decorator"
 import { Title, Canvas, Subtitle, Controls } from "@storybook/blocks"
+
+const size: ArgTypes["size"] = {
+    control: "select",
+    options: ["sm", "base", "md", "lg"],
+    description: "Size of the input",
+    table: {
+        type: {
+            summary: "sm | base | md | lg",
+        },
+        defaultValue: {
+            summary: "base",
+        },
+    },
+}
+
+const variant: ArgTypes["variant"] = {
+    control: "select",
+    options: ["base", "line", "sensitive"],
+    description: "Variant of the input",
+    table: {
+        type: {
+            summary: "base | line | sensitive",
+        },
+        defaultValue: {
+            summary: "base",
+        },
+    },
+}
 
 const meta: Meta = {
     title: "ui-input",
     tags: ["autodocs"],
     component: Input,
     args: {
-        placeholder: "John Doe.",
-        size: "base",
-        variant: "base",
         fullRounded: false,
+        placeholder: "John Doe.",
+        disabled: false,
     },
     argTypes: {
-        variant: {
-            control: "select",
-            options: ["base", "line", "sensitive"],
-            description: "Variant of the input",
-            table: {
-                type: {
-                    summary: "base | line | sensitive",
-                },
-                defaultValue: {
-                    summary: "base",
-                },
-            },
-        },
-        size: {
-            control: "select",
-            options: ["sm", "base", "md", "lg"],
-            description: "Size of the input",
-            table: {
-                type: {
-                    summary: "sm | base | md | lg",
-                },
-                defaultValue: {
-                    summary: "base",
-                },
-            },
-        },
         placeholder: {
             control: "text",
             description: "Placeholder of the input",
@@ -56,11 +57,22 @@ const meta: Meta = {
                 },
             },
         },
+        disabled: {
+            control: "boolean",
+            description: "Disabled input",
+            table: {
+                type: {
+                    summary: "boolean",
+                },
+                defaultValue: {
+                    summary: "false",
+                },
+            },
+        },
     },
     parameters: {
         layout: "centered",
         backgrounds: {
-            default: "light",
             grid: true,
         },
         docs: {
@@ -80,55 +92,75 @@ const meta: Meta = {
 type Story = StoryObj<typeof meta>
 
 export const Base: Story = {
+    args: {
+        size: "base",
+        variant: "base",
+    },
+    argTypes: {
+        size,
+        variant,
+    },
     parameters: {
         skipDecorator: true,
     },
 }
 
 export const Variants: Story = {
-    render: () => (
-        <>
-            <div>
-                <span className="font-medium">base</span>
-                <Input variant="base" placeholder="John Doe." />
-            </div>
-            <div>
-                <span className="font-medium">line</span>
-                <Input variant="line" placeholder="John Doe." />
-            </div>
-            <div>
-                <span className="font-medium">sensitive</span>
-                <Input variant="sensitive" placeholder="John Doe." />
-            </div>
-            <div>
-                <span className="font-medium">disabled</span>
-                <Input variant="base" placeholder="John Doe." disabled />
-            </div>
-        </>
-    ),
+    args: {
+        size: "base",
+    },
+    argTypes: {
+        size,
+    },
+    render: ({ size, placeholder, disabled, fullRounded }) => {
+        const variants = ["base", "line", "sensitive"]
+
+        return (
+            <>
+                {variants.map((variant) => (
+                    <div key={variant}>
+                        <span className="font-medium">{variant}</span>
+                        <Input
+                            variant={variant as any}
+                            size={size}
+                            disabled={disabled}
+                            placeholder={placeholder}
+                            fullRounded={fullRounded}
+                        />
+                    </div>
+                ))}
+            </>
+        )
+    },
 }
 
 export const Sizes: Story = {
-    render: () => (
-        <>
-            <div>
-                <span className="font-medium">small</span>
-                <Input size="sm" placeholder="John Doe." />
-            </div>
-            <div>
-                <span className="font-medium">base</span>
-                <Input size="base" placeholder="John Doe." />
-            </div>
-            <div>
-                <span className="font-medium">medium</span>
-                <Input size="md" placeholder="John Doe." />
-            </div>
-            <div>
-                <span className="font-medium">large</span>
-                <Input size="lg" placeholder="John Doe." />
-            </div>
-        </>
-    ),
+    args: {
+        variant: "base",
+    },
+    argTypes: {
+        variant,
+    },
+    render: ({ variant, placeholder, disabled, fullRounded }) => {
+        const sizes = ["sm", "base", "md", "lg"]
+
+        return (
+            <>
+                {sizes.map((size) => (
+                    <div key={size}>
+                        <span className="font-medium">{size}</span>
+                        <Input
+                            size={size as any}
+                            variant={variant}
+                            disabled={disabled}
+                            placeholder={placeholder}
+                            fullRounded={fullRounded}
+                        />
+                    </div>
+                ))}
+            </>
+        )
+    },
 }
 
 export default meta

--- a/packages/ui-input/src/input.stories.tsx
+++ b/packages/ui-input/src/input.stories.tsx
@@ -1,22 +1,89 @@
 import { Input } from "./index.jsx"
 import type { Meta, StoryObj } from "@storybook/react"
 import { decorator } from "@halvaradop/ui-utils/decorator"
+import { Title, Canvas, Subtitle, Controls } from "@storybook/blocks"
 
 const meta: Meta = {
     title: "ui-input",
     tags: ["autodocs"],
     component: Input,
+    args: {
+        placeholder: "John Doe.",
+        size: "base",
+        variant: "base",
+        fullRounded: false,
+    },
+    argTypes: {
+        variant: {
+            control: "select",
+            options: ["base", "line", "sensitive"],
+            description: "Variant of the input",
+            table: {
+                type: {
+                    summary: "base | line | sensitive",
+                },
+                defaultValue: {
+                    summary: "base",
+                },
+            },
+        },
+        size: {
+            control: "select",
+            options: ["sm", "base", "md", "lg"],
+            description: "Size of the input",
+            table: {
+                type: {
+                    summary: "sm | base | md | lg",
+                },
+                defaultValue: {
+                    summary: "base",
+                },
+            },
+        },
+        placeholder: {
+            control: "text",
+            description: "Placeholder of the input",
+        },
+        fullRounded: {
+            control: "boolean",
+            description: "Rounded input",
+            table: {
+                type: {
+                    summary: "boolean",
+                },
+                defaultValue: {
+                    summary: "false",
+                },
+            },
+        },
+    },
     parameters: {
         layout: "centered",
         backgrounds: {
             default: "light",
             grid: true,
         },
+        docs: {
+            page: () => (
+                <>
+                    <Title />
+                    <Subtitle>Dialog component powered by React & TailwindCSS</Subtitle>
+                    <Canvas />
+                    <Controls />
+                </>
+            ),
+        },
     },
     decorators: [decorator],
 } satisfies Meta<typeof Input>
 
 type Story = StoryObj<typeof meta>
+
+export const Base: Story = {
+    parameters: {
+        skipDecorator: true,
+    },
+}
 
 export const Variants: Story = {
     render: () => (

--- a/packages/ui-label/src/label.stories.tsx
+++ b/packages/ui-label/src/label.stories.tsx
@@ -2,22 +2,76 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { Label } from "./index.js"
 import { Input } from "../../ui-input/src/index.js"
 import { decorator } from "@halvaradop/ui-utils/decorator"
+import { Title, Canvas, Subtitle, Controls } from "@storybook/blocks"
 
 const meta: Meta = {
     title: "ui-label",
     tags: ["autodocs"],
     component: Label,
+    args: {
+        variant: "base",
+        size: "base",
+        children: "Username",
+    },
+    argTypes: {
+        variant: {
+            control: "select",
+            options: ["base", "error", "flex"],
+            description: "Variant of the label",
+            table: {
+                type: {
+                    summary: "base | error | flex",
+                },
+                defaultValue: {
+                    summary: "base",
+                },
+            },
+        },
+        size: {
+            control: "select",
+            options: ["sm", "base", "md"],
+            description: "Size of the label",
+            table: {
+                type: {
+                    summary: "sm | base | md",
+                },
+                defaultValue: {
+                    summary: "base",
+                },
+            },
+        },
+        children: {
+            control: "text",
+            description: "Label text",
+        },
+    },
     parameters: {
         layout: "centered",
         backgrounds: {
             default: "light",
             grid: true,
         },
+        docs: {
+            page: () => (
+                <>
+                    <Title />
+                    <Subtitle>Dialog component powered by React & TailwindCSS</Subtitle>
+                    <Canvas />
+                    <Controls />
+                </>
+            ),
+        },
     },
     decorators: [decorator],
 } satisfies Meta<typeof Label>
 
 type Story = StoryObj<typeof meta>
+
+export const Base: Story = {
+    parameters: {
+        skipDecorator: true,
+    },
+}
 
 export const Sizes: Story = {
     render: () => (

--- a/packages/ui-label/src/label.stories.tsx
+++ b/packages/ui-label/src/label.stories.tsx
@@ -1,45 +1,45 @@
-import type { Meta, StoryObj } from "@storybook/react"
+import type { ArgTypes, Meta, StoryObj } from "@storybook/react"
 import { Label } from "./index.js"
 import { Input } from "../../ui-input/src/index.js"
 import { decorator } from "@halvaradop/ui-utils/decorator"
 import { Title, Canvas, Subtitle, Controls } from "@storybook/blocks"
+
+const size: ArgTypes["size"] = {
+    control: "select",
+    options: ["sm", "base", "md"],
+    description: "Size of the label",
+    table: {
+        type: {
+            summary: "sm | base | md",
+        },
+        defaultValue: {
+            summary: "base",
+        },
+    },
+}
+
+const variant: ArgTypes["variant"] = {
+    control: "select",
+    options: ["base", "error", "flex"],
+    description: "Variant of the label",
+    table: {
+        type: {
+            summary: "base | error | flex",
+        },
+        defaultValue: {
+            summary: "base",
+        },
+    },
+}
 
 const meta: Meta = {
     title: "ui-label",
     tags: ["autodocs"],
     component: Label,
     args: {
-        variant: "base",
-        size: "base",
         children: "Username",
     },
     argTypes: {
-        variant: {
-            control: "select",
-            options: ["base", "error", "flex"],
-            description: "Variant of the label",
-            table: {
-                type: {
-                    summary: "base | error | flex",
-                },
-                defaultValue: {
-                    summary: "base",
-                },
-            },
-        },
-        size: {
-            control: "select",
-            options: ["sm", "base", "md"],
-            description: "Size of the label",
-            table: {
-                type: {
-                    summary: "sm | base | md",
-                },
-                defaultValue: {
-                    summary: "base",
-                },
-            },
-        },
         children: {
             control: "text",
             description: "Label text",
@@ -48,7 +48,6 @@ const meta: Meta = {
     parameters: {
         layout: "centered",
         backgrounds: {
-            default: "light",
             grid: true,
         },
         docs: {
@@ -68,27 +67,38 @@ const meta: Meta = {
 type Story = StoryObj<typeof meta>
 
 export const Base: Story = {
+    args: {
+        size: "base",
+        variant: "base",
+    },
+    argTypes: {
+        size,
+        variant,
+    },
     parameters: {
         skipDecorator: true,
     },
 }
 
 export const Sizes: Story = {
-    render: () => (
-        <div className="flex items-center gap-x-5">
-            <Label size="sm">Small</Label>
-            <Label size="base">Base</Label>
-            <Label size="md">Medium</Label>
+    args: {
+        variant: "base",
+    },
+    argTypes: {
+        variant,
+    },
+    render: ({ children, variant }) => (
+        <div className="w-full flex items-center gap-x-5">
+            <Label size="sm" variant={variant}>
+                {children}
+            </Label>
+            <Label size="base" variant={variant}>
+                {children}
+            </Label>
+            <Label size="md" variant={variant}>
+                {children}
+            </Label>
         </div>
-    ),
-}
-
-export const Flex: Story = {
-    render: () => (
-        <Label className="gap-y-5" variant="flex">
-            <Label>Name</Label>
-            <Label>Lastname</Label>
-        </Label>
     ),
 }
 
@@ -111,7 +121,7 @@ export const Error: Story = {
     ),
 }
 
-export const WithAsChild: Story = {
+export const AsSpan: Story = {
     render: () => (
         <Label asChild>
             <span>Name</span>

--- a/packages/ui-radio-group/src/radio-group.stories.tsx
+++ b/packages/ui-radio-group/src/radio-group.stories.tsx
@@ -49,44 +49,14 @@ export const Base: Story = {
     parameters: {
         skipDecorator: true,
     },
-    render: (args) => (
-        <RadioGroup name="food" {...args}>
+    render: ({ variant }) => (
+        <RadioGroup name="food" variant={variant}>
             <Label className="flex items-center gap-x-2">
                 <Radio value="pizza" name="food" />
                 Pizza
             </Label>
             <Label className="flex items-center gap-x-2">
                 <Radio value="hamburger" name="food" />
-                Hamburger
-            </Label>
-        </RadioGroup>
-    ),
-}
-
-export const Column: Story = {
-    render: () => (
-        <RadioGroup name="food">
-            <Label className="flex items-center gap-x-2">
-                <Radio value="pizza" name="food" />
-                Pizza
-            </Label>
-            <Label className="flex items-center gap-x-2">
-                <Radio value="hamburger" name="food" />
-                Hamburger
-            </Label>
-        </RadioGroup>
-    ),
-}
-
-export const Row: Story = {
-    render: () => (
-        <RadioGroup variant="row" name="food-2">
-            <Label className="flex items-center gap-x-2">
-                <Radio value="pizza" />
-                Pizza
-            </Label>
-            <Label className="flex items-center gap-x-2">
-                <Radio value="hamburger" />
                 Hamburger
             </Label>
         </RadioGroup>

--- a/packages/ui-radio-group/src/radio-group.stories.tsx
+++ b/packages/ui-radio-group/src/radio-group.stories.tsx
@@ -3,68 +3,109 @@ import { RadioGroup } from "./index.js"
 import { Label } from "../../ui-label/src/index.js"
 import { Radio } from "../../ui-radio/src/index.js"
 import { decorator } from "@halvaradop/ui-utils/decorator"
+import { Title, Canvas, Subtitle, Controls } from "@storybook/blocks"
 
 const meta: Meta = {
     title: "ui-radio-group",
     tags: ["autodocs"],
     component: RadioGroup,
+    args: {
+        variant: "column",
+    },
+    argTypes: {
+        variant: {
+            control: "radio",
+            options: ["column", "row"],
+            description: "Flex direction of the radio group",
+            table: {
+                type: {
+                    summary: "column | row",
+                },
+                defaultValue: {
+                    summary: "column",
+                },
+            },
+        },
+    },
     parameters: {
         layout: "centered",
+        docs: {
+            page: () => (
+                <>
+                    <Title />
+                    <Subtitle>Dialog component powered by React & TailwindCSS</Subtitle>
+                    <Canvas />
+                    <Controls />
+                </>
+            ),
+        },
     },
     decorators: [decorator],
 } satisfies Meta<typeof RadioGroup>
 
 type Story = StoryObj<typeof meta>
 
-export const Column: Story = {
-    render: () => {
-        return (
-            <RadioGroup name="food">
-                <Label className="flex items-center gap-x-2">
-                    <Radio value="pizza" name="food" />
-                    Pizza
-                </Label>
-                <Label className="flex items-center gap-x-2">
-                    <Radio value="hamburger" name="food" />
-                    Hamburger
-                </Label>
-            </RadioGroup>
-        )
+export const Base: Story = {
+    parameters: {
+        skipDecorator: true,
     },
+    render: (args) => (
+        <RadioGroup name="food" {...args}>
+            <Label className="flex items-center gap-x-2">
+                <Radio value="pizza" name="food" />
+                Pizza
+            </Label>
+            <Label className="flex items-center gap-x-2">
+                <Radio value="hamburger" name="food" />
+                Hamburger
+            </Label>
+        </RadioGroup>
+    ),
+}
+
+export const Column: Story = {
+    render: () => (
+        <RadioGroup name="food">
+            <Label className="flex items-center gap-x-2">
+                <Radio value="pizza" name="food" />
+                Pizza
+            </Label>
+            <Label className="flex items-center gap-x-2">
+                <Radio value="hamburger" name="food" />
+                Hamburger
+            </Label>
+        </RadioGroup>
+    ),
 }
 
 export const Row: Story = {
-    render: () => {
-        return (
-            <RadioGroup variant="row" name="food-2">
-                <Label className="flex items-center gap-x-2">
-                    <Radio value="pizza" />
-                    Pizza
-                </Label>
-                <Label className="flex items-center gap-x-2">
-                    <Radio value="hamburger" />
-                    Hamburger
-                </Label>
-            </RadioGroup>
-        )
-    },
+    render: () => (
+        <RadioGroup variant="row" name="food-2">
+            <Label className="flex items-center gap-x-2">
+                <Radio value="pizza" />
+                Pizza
+            </Label>
+            <Label className="flex items-center gap-x-2">
+                <Radio value="hamburger" />
+                Hamburger
+            </Label>
+        </RadioGroup>
+    ),
 }
 
 export const DefaultChecked: Story = {
-    render: () => {
-        return (
-            <RadioGroup name="food-3" defaultValue="pizza">
-                <Label className="flex items-center gap-x-2">
-                    <Radio value="pizza" name="food-3" />
-                    Pizza
-                </Label>
-                <Label className="flex items-center gap-x-2">
-                    <Radio value="hamburger" name="food-3" />
-                    Hamburger
-                </Label>
-            </RadioGroup>
-        )
-    },
+    render: () => (
+        <RadioGroup name="food-3" defaultValue="pizza">
+            <Label className="flex items-center gap-x-2">
+                <Radio value="pizza" name="food-3" />
+                Pizza
+            </Label>
+            <Label className="flex items-center gap-x-2">
+                <Radio value="hamburger" name="food-3" />
+                Hamburger
+            </Label>
+        </RadioGroup>
+    ),
 }
 
 export default meta

--- a/packages/ui-radio/src/radio.stories.tsx
+++ b/packages/ui-radio/src/radio.stories.tsx
@@ -3,22 +3,87 @@ import { Radio } from "./index.js"
 import { Label } from "../../ui-label/src/index.js"
 import { RadioGroup } from "../../ui-radio-group/src/index.js"
 import { decorator } from "@halvaradop/ui-utils/decorator"
+import { Title, Canvas, Subtitle, Controls } from "@storybook/blocks"
 
 const meta: Meta = {
     title: "ui-radio",
     tags: ["autodocs"],
     component: Radio,
+    args: {
+        size: "base",
+        color: "primary",
+    },
+    argTypes: {
+        size: {
+            control: "select",
+            options: ["sm", "base", "md", "lg"],
+            description: "Size of the radio",
+            table: {
+                type: {
+                    summary: "sm | base | md | lg",
+                },
+                defaultValue: {
+                    summary: "base",
+                },
+            },
+        },
+        color: {
+            control: "select",
+            options: ["green", "blue", "red", "yellow", "primary"],
+            description: "Color of the radio",
+            table: {
+                type: {
+                    summary: "green | blue | red | yellow | primary",
+                },
+                defaultValue: {
+                    summary: "primary",
+                },
+            },
+        },
+    },
     parameters: {
         layout: "centered",
         backgrounds: {
             default: "light",
             grid: true,
         },
+        docs: {
+            page: () => (
+                <>
+                    <Title />
+                    <Subtitle>Dialog component powered by React & TailwindCSS</Subtitle>
+                    <Canvas />
+                    <Controls />
+                </>
+            ),
+        },
     },
     decorators: [decorator],
 } satisfies Meta<typeof Radio>
 
 type Story = StoryObj<typeof meta>
+
+export const Base: Story = {
+    parameters: {
+        skipDecorator: true,
+    },
+    render: (args) => (
+        <RadioGroup>
+            <Label className="flex items-center gap-x-2">
+                <Radio {...args} />
+            </Label>
+            <Label className="flex items-center gap-x-2">
+                <Radio {...args} />
+            </Label>
+            <Label className="flex items-center gap-x-2">
+                <Radio {...args} />
+            </Label>
+            <Label className="flex items-center gap-x-2">
+                <Radio {...args} />
+            </Label>
+        </RadioGroup>
+    ),
+}
 
 export const Sizes: Story = {
     render: () => (

--- a/packages/ui-radio/src/radio.stories.tsx
+++ b/packages/ui-radio/src/radio.stories.tsx
@@ -1,50 +1,45 @@
-import type { Meta, StoryObj } from "@storybook/react"
+import type { ArgTypes, Meta, StoryObj } from "@storybook/react"
 import { Radio } from "./index.js"
 import { Label } from "../../ui-label/src/index.js"
 import { RadioGroup } from "../../ui-radio-group/src/index.js"
 import { decorator } from "@halvaradop/ui-utils/decorator"
 import { Title, Canvas, Subtitle, Controls } from "@storybook/blocks"
 
+const size: ArgTypes["size"] = {
+    control: "select",
+    options: ["sm", "base", "md", "lg"],
+    description: "Size of the radio",
+    table: {
+        type: {
+            summary: "sm | base | md | lg",
+        },
+        defaultValue: {
+            summary: "base",
+        },
+    },
+}
+
+const color: ArgTypes["color"] = {
+    control: "select",
+    options: ["green", "blue", "red", "yellow", "primary"],
+    description: "Color of the radio",
+    table: {
+        type: {
+            summary: "green | blue | red | yellow | primary",
+        },
+        defaultValue: {
+            summary: "primary",
+        },
+    },
+}
+
 const meta: Meta = {
     title: "ui-radio",
     tags: ["autodocs"],
     component: Radio,
-    args: {
-        size: "base",
-        color: "primary",
-    },
-    argTypes: {
-        size: {
-            control: "select",
-            options: ["sm", "base", "md", "lg"],
-            description: "Size of the radio",
-            table: {
-                type: {
-                    summary: "sm | base | md | lg",
-                },
-                defaultValue: {
-                    summary: "base",
-                },
-            },
-        },
-        color: {
-            control: "select",
-            options: ["green", "blue", "red", "yellow", "primary"],
-            description: "Color of the radio",
-            table: {
-                type: {
-                    summary: "green | blue | red | yellow | primary",
-                },
-                defaultValue: {
-                    summary: "primary",
-                },
-            },
-        },
-    },
     parameters: {
         layout: "centered",
         backgrounds: {
-            default: "light",
             grid: true,
         },
         docs: {
@@ -64,72 +59,92 @@ const meta: Meta = {
 type Story = StoryObj<typeof meta>
 
 export const Base: Story = {
+    args: {
+        size: "base",
+        color: "primary",
+    },
+    argTypes: {
+        size,
+        color,
+    },
     parameters: {
         skipDecorator: true,
     },
-    render: (args) => (
+    render: ({ size, color }) => (
         <RadioGroup>
             <Label className="flex items-center gap-x-2">
-                <Radio {...args} />
+                <Radio size={size} color={color} />
             </Label>
             <Label className="flex items-center gap-x-2">
-                <Radio {...args} />
+                <Radio size={size} color={color} />
             </Label>
             <Label className="flex items-center gap-x-2">
-                <Radio {...args} />
+                <Radio size={size} color={color} />
             </Label>
             <Label className="flex items-center gap-x-2">
-                <Radio {...args} />
+                <Radio size={size} color={color} />
             </Label>
         </RadioGroup>
     ),
 }
 
 export const Sizes: Story = {
-    render: () => (
+    args: {
+        color: "primary",
+    },
+    argTypes: {
+        color,
+    },
+    render: ({ color }) => (
         <RadioGroup>
             <Label className="flex items-center gap-x-2">
                 sm
-                <Radio size="sm" />
+                <Radio size="sm" color={color} />
             </Label>
             <Label className="flex items-center gap-x-2">
                 base
-                <Radio size="base" />
+                <Radio size="base" color={color} />
             </Label>
             <Label className="flex items-center gap-x-2">
                 md
-                <Radio size="md" />
+                <Radio size="md" color={color} />
             </Label>
             <Label className="flex items-center gap-x-2">
                 lg
-                <Radio size="lg" />
+                <Radio size="lg" color={color} />
             </Label>
         </RadioGroup>
     ),
 }
 
 export const Colors: Story = {
-    render: () => (
+    args: {
+        size: "base",
+    },
+    argTypes: {
+        size,
+    },
+    render: ({ size }) => (
         <RadioGroup>
             <Label className="flex items-center gap-x-2">
                 green
-                <Radio color="green" />
+                <Radio color="green" size={size} />
             </Label>
             <Label className="flex items-center gap-x-2">
                 blue
-                <Radio color="blue" />
+                <Radio color="blue" size={size} />
             </Label>
             <Label className="flex items-center gap-x-2">
                 red
-                <Radio color="red" />
+                <Radio color="red" size={size} />
             </Label>
             <Label className="flex items-center gap-x-2">
                 yellow
-                <Radio color="yellow" />
+                <Radio color="yellow" size={size} />
             </Label>
             <Label className="flex items-center gap-x-2">
                 primary
-                <Radio color="primary" />
+                <Radio color="primary" size={size} />
             </Label>
         </RadioGroup>
     ),

--- a/packages/ui-submit/src/submit.stories.tsx
+++ b/packages/ui-submit/src/submit.stories.tsx
@@ -3,16 +3,43 @@ import { FormEvent, useTransition } from "react"
 import type { Meta, StoryObj } from "@storybook/react"
 import { Submit } from "./index.js"
 import { decorator } from "@halvaradop/ui-utils/decorator"
+import { Title, Canvas, Subtitle, Controls } from "@storybook/blocks"
 
 const meta: Meta = {
     title: "ui-submit",
     tags: ["autodocs"],
     component: Submit,
+    args: {
+        value: "Submit",
+        pending: "Submitting...",
+        disabled: false,
+    },
+    argTypes: {
+        value: {
+            description: "The text to display on the button",
+        },
+        pending: {
+            description: "The text to display on the button when it's in a pending state",
+        },
+        disabled: {
+            description: "Whether the button is disabled",
+        },
+    },
     parameters: {
         layout: "centered",
         backgrounds: {
             default: "light",
             grid: true,
+        },
+        docs: {
+            page: () => (
+                <>
+                    <Title />
+                    <Subtitle>Dialog component powered by React & TailwindCSS</Subtitle>
+                    <Canvas />
+                    <Controls />
+                </>
+            ),
         },
     },
     decorators: [decorator],
@@ -43,6 +70,12 @@ const Template = ({ className, ...props }: Parameters<typeof Submit>[0]) => {
             <Submit disabled={isPending} aria-disabled={isPending} {...props} />
         </form>
     )
+}
+
+export const Base: Story = {
+    parameters: {
+        skipDecorator: true,
+    },
 }
 
 export const Variants: Story = {

--- a/packages/ui-submit/src/submit.stories.tsx
+++ b/packages/ui-submit/src/submit.stories.tsx
@@ -1,18 +1,46 @@
 "use client"
 import { FormEvent, useTransition } from "react"
-import type { Meta, StoryObj } from "@storybook/react"
+import type { ArgTypes, Meta, StoryObj } from "@storybook/react"
 import { Submit } from "./index.js"
 import { decorator } from "@halvaradop/ui-utils/decorator"
 import { Title, Canvas, Subtitle, Controls } from "@storybook/blocks"
+
+const size: ArgTypes["size"] = {
+    control: "select",
+    options: ["sm", "base", "md", "lg"],
+    description: "The size of the button",
+    table: {
+        type: {
+            summary: "sm | base | md | lg",
+        },
+        defaultValue: {
+            summary: "base",
+        },
+    },
+}
+
+const variant: ArgTypes["variant"] = {
+    control: "select",
+    options: ["base", "secondary", "inverted"],
+    description: "The variant of the button",
+    table: {
+        type: {
+            summary: "base | secondary | inverted",
+        },
+        defaultValue: {
+            summary: "base",
+        },
+    },
+}
 
 const meta: Meta = {
     title: "ui-submit",
     tags: ["autodocs"],
     component: Submit,
     args: {
+        disabled: false,
         value: "Submit",
         pending: "Submitting...",
-        disabled: false,
     },
     argTypes: {
         value: {
@@ -23,12 +51,16 @@ const meta: Meta = {
         },
         disabled: {
             description: "Whether the button is disabled",
+            table: {
+                defaultValue: {
+                    summary: "false",
+                },
+            },
         },
     },
     parameters: {
         layout: "centered",
         backgrounds: {
-            default: "light",
             grid: true,
         },
         docs: {
@@ -47,77 +79,74 @@ const meta: Meta = {
 
 type Story = StoryObj<typeof meta>
 
-/**
- * Note: The `useTransition` hook doesn't support async callbacks directly. As a result,
- * the pending state will only be visible momentarily.
- * To observe the pending state for a longer duration, consider using React 19 (available in the beta branch)
- * or frameworks like Next.js that support Server-Side Rendering.
- */
-const Template = ({ className, ...props }: Parameters<typeof Submit>[0]) => {
-    const [isPending, startTransition] = useTransition()
-
-    const wait = async () => await new Promise<string>((resolve) => setTimeout(resolve, 2000))
-
-    const handleSubmit = async (event: FormEvent) => {
-        event.preventDefault()
-        startTransition(() => {
-            wait()
-        })
-    }
-
-    return (
-        <form className={className} onSubmit={handleSubmit}>
-            <Submit disabled={isPending} aria-disabled={isPending} {...props} />
-        </form>
-    )
-}
-
 export const Base: Story = {
+    args: {
+        size: "base",
+        variant: "base",
+    },
+    argTypes: {
+        size,
+        variant,
+    },
     parameters: {
         skipDecorator: true,
     },
 }
 
 export const Variants: Story = {
-    render: () => (
-        <>
-            <div>
-                <span className="font-medium">base</span>
-                <Template />
-            </div>
-            <div>
-                <span className="font-medium">seconday</span>
-                <Template variant="secondary" />
-            </div>
-            <div>
-                <span className="font-medium">inverted</span>
-                <Template variant="inverted" />
-            </div>
-        </>
-    ),
+    args: {
+        size: "base",
+    },
+    argTypes: {
+        size,
+    },
+    render: ({ size, disabled, pending, value }) => {
+        const variants = ["base", "secondary", "inverted"]
+        return (
+            <>
+                {variants.map((variant) => (
+                    <div key={variant}>
+                        <span className="font-medium block">{variant}</span>
+                        <Submit
+                            variant={variant as any}
+                            size={size}
+                            value={value}
+                            pending={pending}
+                            disabled={disabled}
+                        />
+                    </div>
+                ))}
+            </>
+        )
+    },
 }
 
 export const Sizes: Story = {
-    render: () => (
-        <>
-            <div>
-                <span className="font-medium">sm</span>
-                <Template size="sm" />
-            </div>
-            <div>
-                <span className="font-medium">base</span>
-                <Template size="base" />
-            </div>
-            <div>
-                <span className="font-medium">md</span>
-                <Template size="md" />
-            </div>
-            <div>
-                <span className="font-medium">lg</span>
-                <Template size="lg" />
-            </div>
-        </>
-    ),
+    args: {
+        variant: "base",
+    },
+    argTypes: {
+        variant,
+    },
+    render: ({ value, pending, disabled, variant }) => {
+        const sizes = ["sm", "base", "md", "lg"]
+        return (
+            <>
+                {sizes.map((size) => (
+                    <div key={size}>
+                        <span className="font-medium block">{size}</span>
+                        <Submit
+                            size={size as any}
+                            variant={variant}
+                            value={value}
+                            pending={pending}
+                            disabled={disabled}
+                        />
+                    </div>
+                ))}
+            </>
+        )
+    },
 }
 
 export default meta

--- a/packages/ui-template/src/index.stories.tsx
+++ b/packages/ui-template/src/index.stories.tsx
@@ -1,22 +1,41 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import { Index } from "./index.jsx"
 import { decorator } from "@halvaradop/ui-utils/decorator"
+import { Title, Canvas, Subtitle, Controls } from "@storybook/blocks"
 
 const meta: Meta = {
     title: "ui-index",
     tags: ["autodocs"],
     component: Index,
+    args: {},
+    argTypes: {},
     parameters: {
         layout: "centered",
         backgrounds: {
             default: "light",
             grid: true,
         },
+        docs: {
+            page: () => (
+                <>
+                    <Title />
+                    <Subtitle>Template component powered by React & TailwindCSS</Subtitle>
+                    <Canvas />
+                    <Controls />
+                </>
+            ),
+        },
     },
     decorators: [decorator],
 } satisfies Meta<typeof Index>
 
 type Story = StoryObj<typeof meta>
+
+export const Base: Story = {
+    parameters: {
+        skipDecorator: true,
+    },
+}
 
 export const Variants: Story = {}
 

--- a/packages/ui-utils/src/decorator.tsx
+++ b/packages/ui-utils/src/decorator.tsx
@@ -2,7 +2,9 @@ import { useEffect, useState } from "react"
 import { Button } from "@halvaradop/ui-button"
 import type { Decorator } from "@storybook/react"
 
-export const decorator: Decorator = (Story) => {
+export const decorator: Decorator = (Story, { parameters }) => {
+    if (parameters.skipDecorator) return <Story />
+
     const [isDark, setIsDark] = useState(false)
 
     const handleToggleTheme = () => {


### PR DESCRIPTION
## Description

This pull request improves the stories for components by adding `args` and `argTypes` controls, allowing users to see the UI changes when they update the variants of the component. Additionally, Doc Blocks documentation supported by Storybook is introduced to show the main props of components and provide brief information about these props and their default values.

The main reason for implementing Doc Blocks was that the main Stories implement a decorator imported from `@halvaradop/ui-utils/decorator`. This decorator adds an extra container and styles, creating a wrapper for switching between themes like light and dark theme, which caused a bad render UI. A new parameter called `skipDecorator` was added to the story, allowing the exclusion of the decorator for a specific story that sets this parameter. The following picture shows the previous UI behavior before the changes:

### After
![image](https://github.com/user-attachments/assets/e07fd732-eac8-4fec-b888-31d063f963da)

### Before
![image](https://github.com/user-attachments/assets/6c8ad265-eee1-4d1a-8266-6807d8994c5f)

Finally, unnecessary code was removed from stories, and stories were cleaned up by removing duplicated code and creating renders by list.

### Key Changes

- Added `args` to stories in `meta` object
- Added `argTypes` to stories in `meta` object
- Included Doc Blocks Documentation

## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
