### PR TITLE
chore(release): bump package versions

### DIFF
--- a/packages/ui-button/package.json
+++ b/packages/ui-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-button",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A customizable button component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",
   "scripts": {

--- a/packages/ui-checkbox/package.json
+++ b/packages/ui-checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-checkbox",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": false,
   "description": "A customizable Checkbox component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-core",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "The core of the @halvaradop/ui library, providing customizable components with Tailwind CSS styling.",
   "type": "module",
   "scripts": {

--- a/packages/ui-dialog/package.json
+++ b/packages/ui-dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-dialog",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": false,
   "description": "A customizable dialog component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",

--- a/packages/ui-form/package.json
+++ b/packages/ui-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-form",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": false,
   "description": "A customizable form component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",

--- a/packages/ui-input/package.json
+++ b/packages/ui-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-input",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": false,
   "description": "A customizable input component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",

--- a/packages/ui-label/package.json
+++ b/packages/ui-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-label",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": false,
   "description": "A customizable label component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",

--- a/packages/ui-radio-group/package.json
+++ b/packages/ui-radio-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-radio-group",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": false,
   "description": "A customizable Radio Group component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",

--- a/packages/ui-radio/package.json
+++ b/packages/ui-radio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-radio",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": false,
   "description": "A customizable radio button component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",

--- a/packages/ui-submit/package.json
+++ b/packages/ui-submit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-submit",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": false,
   "description": "A customizable submit component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",


### PR DESCRIPTION
## Description

This pull request introduces new versions of the packages available in the `@halvaradop/ui` library of components. These new versions add support for CSS variables for styling components based on the user's design system, allowing users to customize the components according to their preferences. Additionally, it adds documentation to the `README.md` files available in the package in the monorepo and on the npm website, enabling users to read the documentation on npm without having to visit GitHub.

Previous changes were introduced in the pull requests:
- #93
- #95

### Bumped Packages
- `@halvaradop/ui-button`
- `@halvaradop/ui-checkbox`
- `@halvaradop/ui-core`
- `@halvaradop/ui-dialog`
- `@halvaradop/ui-form`
- `@halvaradop/ui-input`
- `@halvaradop/ui-label`
- `@halvaradop/ui-radio`
- `@halvaradop/ui-radio-group`
- `@halvaradop/ui-submit`

## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
