### PR TITLE
chore(dependencies): add `react` and `react-dom` as `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
     "vite": "^6.2.1"
   },
   "peerDependencies": {
-    "react": ">=18",
-    "react-dom": ">=18"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "packageManager": "pnpm@10.3.0",
   "engines": {

--- a/packages/ui-button/package.json
+++ b/packages/ui-button/package.json
@@ -53,5 +53,9 @@
   },
   "devDependencies": {
     "@halvaradop/ui-utils": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   }
 }

--- a/packages/ui-checkbox/package.json
+++ b/packages/ui-checkbox/package.json
@@ -53,5 +53,9 @@
   },
   "devDependencies": {
     "@halvaradop/ui-utils": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   }
 }

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -62,5 +62,9 @@
   "devDependencies": {
     "clsx": "^2.1.1",
     "@halvaradop/ui-utils": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   }
 }

--- a/packages/ui-dialog/package.json
+++ b/packages/ui-dialog/package.json
@@ -55,5 +55,9 @@
   "devDependencies": {
     "@halvaradop/ui-button": "workspace:*",
     "@halvaradop/ui-utils": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   }
 }

--- a/packages/ui-form/package.json
+++ b/packages/ui-form/package.json
@@ -56,5 +56,9 @@
     "@halvaradop/ui-utils": "workspace:*",
     "@halvaradop/ui-input": "workspace:*",
     "@halvaradop/ui-label": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   }
 }

--- a/packages/ui-input/package.json
+++ b/packages/ui-input/package.json
@@ -54,5 +54,9 @@
   },
   "devDependencies": {
     "@halvaradop/ui-utils": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   }
 }

--- a/packages/ui-label/package.json
+++ b/packages/ui-label/package.json
@@ -55,5 +55,9 @@
   "devDependencies": {
     "@halvaradop/ui-utils": "workspace:*",
     "@halvaradop/ui-input": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   }
 }

--- a/packages/ui-radio/package.json
+++ b/packages/ui-radio/package.json
@@ -51,5 +51,9 @@
   "devDependencies": {
     "@halvaradop/ui-utils": "workspace:*",
     "@halvaradop/ui-label": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   }
 }

--- a/packages/ui-submit/package.json
+++ b/packages/ui-submit/package.json
@@ -53,5 +53,9 @@
   },
   "devDependencies": {
     "@halvaradop/ui-utils": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,12 @@ importers:
       class-variance-authority:
         specifier: 0.7.0
         version: 0.7.0
+      react:
+        specifier: ^18.0.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.0.0
+        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@halvaradop/ui-utils':
         specifier: workspace:*
@@ -108,6 +114,12 @@ importers:
       class-variance-authority:
         specifier: 0.7.0
         version: 0.7.0
+      react:
+        specifier: ^18.0.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.0.0
+        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@halvaradop/ui-utils':
         specifier: workspace:*
@@ -115,6 +127,12 @@ importers:
 
   packages/ui-core:
     dependencies:
+      react:
+        specifier: ^18.0.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.0.0
+        version: 18.3.1(react@18.3.1)
       tailwind-merge:
         specifier: ^2.5.2
         version: 2.6.0
@@ -134,6 +152,12 @@ importers:
       class-variance-authority:
         specifier: 0.7.0
         version: 0.7.0
+      react:
+        specifier: ^18.0.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.0.0
+        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@halvaradop/ui-button':
         specifier: workspace:*
@@ -150,6 +174,12 @@ importers:
       class-variance-authority:
         specifier: 0.7.0
         version: 0.7.0
+      react:
+        specifier: ^18.0.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.0.0
+        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@halvaradop/ui-input':
         specifier: workspace:*
@@ -169,6 +199,12 @@ importers:
       class-variance-authority:
         specifier: 0.7.0
         version: 0.7.0
+      react:
+        specifier: ^18.0.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.0.0
+        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@halvaradop/ui-utils':
         specifier: workspace:*
@@ -182,6 +218,12 @@ importers:
       class-variance-authority:
         specifier: 0.7.0
         version: 0.7.0
+      react:
+        specifier: ^18.0.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.0.0
+        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@halvaradop/ui-input':
         specifier: workspace:*
@@ -198,6 +240,12 @@ importers:
       class-variance-authority:
         specifier: 0.7.0
         version: 0.7.0
+      react:
+        specifier: ^18.0.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.0.0
+        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@halvaradop/ui-label':
         specifier: workspace:*
@@ -239,6 +287,12 @@ importers:
       class-variance-authority:
         specifier: 0.7.0
         version: 0.7.0
+      react:
+        specifier: ^18.0.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.0.0
+        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@halvaradop/ui-utils':
         specifier: workspace:*


### PR DESCRIPTION

## Description

This pull request adds `react` and `react-dom` as `peerDependencies` in the `package.json` of the library's packages. 

The required version to install the standard version of the components requires `react` version 18, including any new minor or patch upgrades. However, this is not compatible with `react` version 19 due to the breaking changes introduced in the latest version of React (19).


<!--Provide a detailed description or reasoning for the changes made -->

## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
