### PR TITLE
chore(release): bump package versions

### DIFF
--- a/packages/ui-dialog/package.json
+++ b/packages/ui-dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-dialog",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": false,
   "description": "A customizable Dialog component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",

--- a/packages/ui-radio-group/package.json
+++ b/packages/ui-radio-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-radio-group",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": false,
   "description": "A customizable Radio Group component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",


### PR DESCRIPTION

## Description

This pull request introduces new versions of @halvaradop/ui-dialog and @halvaradop/ui-radio-group packages available in @halvaradop/ui library of components. The new versions address and solve miskates and bugs discussed in the opened issues #118 and #121 which mention the two packages that will be published on npm. Even though the @halvaradop/ui-radio-group is not stable and the behavior is not the expected

Previous changes were introduces in the pull requests:
- #122
- #124

### Bumped Packages
- `@halvaradop/ui-dialog`
- `@halvaradop/ui-radio-group`

<!--Provide a detailed description or reasoning for the changes made -->

## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
