### PR TITLE
[SYNC] chore: optimize bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "turbo run dev --parallel",
     "build": "turbo run build",
     "build:storybook": "storybook build",
-    "build:release": "turbo build:release --parallel",
+    "build:release": "turbo build:release",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "storybook": "storybook dev -p 6006",
@@ -18,7 +18,8 @@
     "clean": "turbo run clean --parallel",
     "clean:dist": "turbo run clean:dist --parallel",
     "clean:modules": "turbo run clean:modules --parallel",
-    "clean:turbo": "turbo run clean:turbo --parallel"
+    "clean:turbo": "turbo run clean:turbo --parallel",
+    "clean:cts": "turbo run clean:cts --parallel"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-button/package.json
+++ b/packages/ui-button/package.json
@@ -5,14 +5,15 @@
   "type": "module",
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
-    "build:release": "sh -c 'export NODE_ENV=production ; tsup'",
+    "build": "tsup && pnpm clean:cts",
+    "build:release": "sh -c 'export NODE_ENV=production ; tsup' && pnpm clean:cts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
     "clean:dist": "rm -rf dist",
     "clean:modules": "rm -rf node_modules",
-    "clean:turbo": "rm -rf .turbo"
+    "clean:turbo": "rm -rf .turbo",
+    "clean:cts": "rm -rf ./dist/*.cts"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-checkbox/package.json
+++ b/packages/ui-checkbox/package.json
@@ -6,14 +6,15 @@
   "type": "module",
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
-    "build:release": "sh -c 'export NODE_ENV=production ; tsup'",
+    "build": "tsup && pnpm clean:cts",
+    "build:release": "sh -c 'export NODE_ENV=production ; tsup' && pnpm clean:cts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
     "clean:dist": "rm -rf dist",
     "clean:modules": "rm -rf node_modules",
-    "clean:turbo": "rm -rf .turbo"
+    "clean:turbo": "rm -rf .turbo",
+    "clean:cts": "rm -rf ./dist/*.cts"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -5,14 +5,15 @@
   "type": "module",
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
-    "build:release": "sh -c 'export NODE_ENV=production ; tsup'",
+    "build": "tsup && pnpm clean:cts",
+    "build:release": "sh -c 'export NODE_ENV=production ; tsup' && pnpm clean:cts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
     "clean:dist": "rm -rf dist",
     "clean:modules": "rm -rf node_modules",
-    "clean:turbo": "rm -rf .turbo"
+    "clean:turbo": "rm -rf .turbo",
+    "clean:cts": "rm -rf ./dist/*.cts"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-dialog/package.json
+++ b/packages/ui-dialog/package.json
@@ -6,14 +6,15 @@
   "type": "module",
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
-    "build:release": "sh -c 'export NODE_ENV=production ; tsup'",
+    "build": "tsup && pnpm clean:cts",
+    "build:release": "sh -c 'export NODE_ENV=production ; tsup' && pnpm clean:cts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
     "clean:dist": "rm -rf dist",
     "clean:modules": "rm -rf node_modules",
-    "clean:turbo": "rm -rf .turbo"
+    "clean:turbo": "rm -rf .turbo",
+    "clean:cts": "rm -rf ./dist/*.cts"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-form/package.json
+++ b/packages/ui-form/package.json
@@ -6,14 +6,15 @@
   "type": "module",
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
-    "build:release": "sh -c 'export NODE_ENV=production ; tsup'",
+    "build": "tsup && pnpm clean:cts",
+    "build:release": "sh -c 'export NODE_ENV=production ; tsup' && pnpm clean:cts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
     "clean:dist": "rm -rf dist",
     "clean:modules": "rm -rf node_modules",
-    "clean:turbo": "rm -rf .turbo"
+    "clean:turbo": "rm -rf .turbo",
+    "clean:cts": "rm -rf ./dist/*.cts"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-input/package.json
+++ b/packages/ui-input/package.json
@@ -6,14 +6,15 @@
   "type": "module",
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
-    "build:release": "sh -c 'export NODE_ENV=production ; tsup'",
+    "build": "tsup && pnpm clean:cts",
+    "build:release": "sh -c 'export NODE_ENV=production ; tsup' && pnpm clean:cts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
     "clean:dist": "rm -rf dist",
     "clean:modules": "rm -rf node_modules",
-    "clean:turbo": "rm -rf .turbo"
+    "clean:turbo": "rm -rf .turbo",
+    "clean:cts": "rm -rf ./dist/*.cts"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-label/package.json
+++ b/packages/ui-label/package.json
@@ -6,14 +6,15 @@
   "type": "module",
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
-    "build:release": "sh -c 'export NODE_ENV=production ; tsup'",
+    "build": "tsup && pnpm clean:cts",
+    "build:release": "sh -c 'export NODE_ENV=production ; tsup' && pnpm clean:cts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
     "clean:dist": "rm -rf dist",
     "clean:modules": "rm -rf node_modules",
-    "clean:turbo": "rm -rf .turbo"
+    "clean:turbo": "rm -rf .turbo",
+    "clean:cts": "rm -rf ./dist/*.cts"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-radio-group/package.json
+++ b/packages/ui-radio-group/package.json
@@ -6,14 +6,15 @@
   "type": "module",
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
-    "build:release": "sh -c 'export NODE_ENV=production ; tsup'",
+    "build": "tsup && pnpm clean:cts",
+    "build:release": "sh -c 'export NODE_ENV=production ; tsup' && pnpm clean:cts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
     "clean:dist": "rm -rf dist",
     "clean:modules": "rm -rf node_modules",
-    "clean:turbo": "rm -rf .turbo"
+    "clean:turbo": "rm -rf .turbo",
+    "clean:cts": "rm -rf ./dist/*.cts"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-radio/package.json
+++ b/packages/ui-radio/package.json
@@ -7,14 +7,15 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
-    "build:release": "sh -c 'export NODE_ENV=production ; tsup'",
+    "build": "tsup && pnpm clean:cts",
+    "build:release": "sh -c 'export NODE_ENV=production ; tsup' && pnpm clean:cts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
     "clean:dist": "rm -rf dist",
     "clean:modules": "rm -rf node_modules",
-    "clean:turbo": "rm -rf .turbo"
+    "clean:turbo": "rm -rf .turbo",
+    "clean:cts": "rm -rf ./dist/*.cts"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-select/package.json
+++ b/packages/ui-select/package.json
@@ -6,14 +6,15 @@
   "type": "module",
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
-    "build:release": "sh -c 'export NODE_ENV=production ; tsup'",
+    "build": "tsup && pnpm clean:cts",
+    "build:release": "sh -c 'export NODE_ENV=production ; tsup' && pnpm clean:cts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
     "clean:dist": "rm -rf dist",
     "clean:modules": "rm -rf node_modules",
-    "clean:turbo": "rm -rf .turbo"
+    "clean:turbo": "rm -rf .turbo",
+    "clean:cts": "rm -rf ./dist/*.cts"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-slot/package.json
+++ b/packages/ui-slot/package.json
@@ -6,14 +6,15 @@
   "type": "module",
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
-    "build:release": "sh -c 'export NODE_ENV=production ; tsup'",
+    "build": "tsup && pnpm clean:cts",
+    "build:release": "sh -c 'export NODE_ENV=production ; tsup' && pnpm clean:cts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
     "clean:dist": "rm -rf dist",
     "clean:modules": "rm -rf node_modules",
-    "clean:turbo": "rm -rf .turbo"
+    "clean:turbo": "rm -rf .turbo",
+    "clean:cts": "rm -rf ./dist/*.cts"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-submit/package.json
+++ b/packages/ui-submit/package.json
@@ -6,14 +6,15 @@
   "type": "module",
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
-    "build:release": "sh -c 'export NODE_ENV=production ; tsup'",
+    "build": "tsup && pnpm clean:cts",
+    "build:release": "sh -c 'export NODE_ENV=production ; tsup' && pnpm clean:cts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
     "clean:dist": "rm -rf dist",
     "clean:modules": "rm -rf node_modules",
-    "clean:turbo": "rm -rf .turbo"
+    "clean:turbo": "rm -rf .turbo",
+    "clean:cts": "rm -rf ./dist/*.cts"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-template/package.json
+++ b/packages/ui-template/package.json
@@ -6,14 +6,15 @@
   "type": "module",
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
-    "build:release": "sh -c 'export NODE_ENV=production ; tsup'",
+    "build": "tsup && pnpm clean:cts",
+    "build:release": "sh -c 'export NODE_ENV=production ; tsup' && pnpm clean:cts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
     "clean:dist": "rm -rf dist",
     "clean:modules": "rm -rf node_modules",
-    "clean:turbo": "rm -rf .turbo"
+    "clean:turbo": "rm -rf .turbo",
+    "clean:cts": "rm -rf ./dist/*.cts"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-utils/package.json
+++ b/packages/ui-utils/package.json
@@ -6,14 +6,15 @@
   "type": "module",
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
-    "build:release": "sh -c 'export NODE_ENV=production ; tsup'",
+    "build": "tsup && pnpm clean:cts",
+    "build:release": "sh -c 'export NODE_ENV=production ; tsup' && pnpm clean:cts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "clean": "turbo run clean:dist clean:modules clean:turbo --parallel",
     "clean:dist": "rm -rf dist",
     "clean:modules": "rm -rf node_modules",
-    "clean:turbo": "rm -rf .turbo"
+    "clean:turbo": "rm -rf .turbo",
+    "clean:cts": "rm -rf ./dist/*.cts"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-utils/src/tsup.config.base.ts
+++ b/packages/ui-utils/src/tsup.config.base.ts
@@ -13,5 +13,5 @@ export const tsupConfig: Options = {
     sourcemap: env !== "production",
     minify: env === "production",
     bundle: env === "production",
-    external: ["vite", "tailwindcss"],
+    external: ["vite", "tailwindcss", "react", "react-dom"],
 }

--- a/turbo.json
+++ b/turbo.json
@@ -30,6 +30,9 @@
     },
     "clean:turbo": {
       "cache": false
+    },
+    "clean:cts": {
+      "cache": false
     }
   },
   "ui": "tui",


### PR DESCRIPTION
## Description

This pull request improves the bundle size of the packages by marking `react` and `react-dom` as external dependencies in the `tsup` configuration. This ensures these libraries are excluded from the package bundles, reducing overall bundle size. Additionally, it removes unnecessary `.d.cts` declaration files generated by `tsup`.

These changes were originally introduced in [#88] and are now being synchronized into the `beta` branch.


> [!Note]
> Only the aforementioned changes have been synchronized from the master branch to the beta branch. This pull request was created to minimize potential issues during synchronization.

<!--Provide a detailed description or reasoning for the changes made -->

## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [ ] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
