### PR TITLE
[SYNC] test(storybook): add play functions in storybook

### DIFF
--- a/packages/ui-button/src/button.stories.tsx
+++ b/packages/ui-button/src/button.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj, ArgTypes } from "@storybook/react"
+import { userEvent, within } from "@storybook/test"
 import { Button } from "./index.jsx"
 import { decorator } from "@halvaradop/ui-utils/decorator"
 import { DocsPage } from "@halvaradop/ui-utils/docs-page"
@@ -113,6 +114,15 @@ export const Variants: Story = {
                 ))}
             </>
         )
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement)
+        const buttons = await canvas.findAllByRole("button")
+        for (const button of buttons.slice(1)) {
+            await new Promise((resolve) => setTimeout(resolve, 1000))
+            button.focus()
+            await userEvent.tab()
+        }
     },
 }
 

--- a/packages/ui-checkbox/src/checkbox.stories.tsx
+++ b/packages/ui-checkbox/src/checkbox.stories.tsx
@@ -1,4 +1,5 @@
 import type { ArgTypes, Meta, StoryObj } from "@storybook/react"
+import { expect, userEvent, within } from "@storybook/test"
 import { Checkbox } from "./index.js"
 import { decorator } from "@halvaradop/ui-utils/decorator"
 import { DocsPage } from "@halvaradop/ui-utils/docs-page"
@@ -74,6 +75,20 @@ const meta: Meta = {
         },
     },
     decorators: [decorator],
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement)
+        const checkboxs = await canvas.findAllByRole("checkbox")
+        for (const checkbox of checkboxs) {
+            await new Promise((resolve) => setTimeout(resolve, 750))
+            checkbox.focus()
+            expect(checkbox).toHaveFocus()
+            await userEvent.click(checkbox)
+            expect(checkbox).toBeChecked()
+            await new Promise((resolve) => setTimeout(resolve, 750))
+            await userEvent.click(checkbox)
+            expect(checkbox).not.toBeChecked()
+        }
+    },
 } satisfies Meta<typeof Checkbox>
 
 type Story = StoryObj<typeof meta>

--- a/packages/ui-dialog/src/dialog.stories.tsx
+++ b/packages/ui-dialog/src/dialog.stories.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react"
 import type { Meta, StoryObj } from "@storybook/react"
+import { within, expect } from "@storybook/test"
 import { Dialog, modalVariants } from "./index.js"
 import { Button } from "@/ui/ui-button/src/index.js"
 import { decorator } from "@halvaradop/ui-utils/decorator"
@@ -90,6 +91,27 @@ export const Base: Story = {
                 </Dialog>
             </>
         )
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement)
+        const openButton = canvas.getByRole("button", { name: /open/i })
+        openButton.click()
+
+        const modal = canvas.getByRole("dialog")
+        expect(modal.hasAttribute("open")).toBeTruthy()
+
+        expect(canvas.getByText(/Modal Content/i)).toBeInTheDocument()
+        expect(canvas.getByText(/size:/i)).toHaveTextContent(/size: (sm|base|md|lg)/i)
+        expect(canvas.getByText(/variant:/i)).toHaveTextContent(/variant: (base|inner|fixed)/i)
+
+        expect(document.activeElement === modal || modal.contains(document.activeElement)).toBeTruthy()
+
+        await new Promise((resolve) => setTimeout(resolve, 500))
+
+        const closeButton = canvas.getByRole("button", { name: /close/i })
+        closeButton.click()
+
+        expect(modal.hasAttribute("open")).toBeFalsy()
     },
 }
 

--- a/packages/ui-form/src/form.stories.tsx
+++ b/packages/ui-form/src/form.stories.tsx
@@ -1,7 +1,10 @@
+import { ChangeEvent, FormEvent, useState } from "react"
 import type { Meta, StoryObj } from "@storybook/react"
+import { expect, userEvent, within } from "@storybook/test"
 import { Form } from "./index.js"
 import { Input } from "@/ui/ui-input/src/index.js"
 import { Label } from "@/ui/ui-label/src/index.js"
+import { Submit } from "@/ui/ui-submit/src/index.js"
 import { decorator } from "@halvaradop/ui-utils/decorator"
 import { DocsPage } from "@halvaradop/ui-utils/docs-page"
 
@@ -56,18 +59,42 @@ export const Base: Story = {
     parameters: {
         skipDecorator: true,
     },
-    render: ({ size, variant }) => (
-        <Form size={size} variant={variant}>
-            <Label>
-                Username
-                <Input />
-            </Label>
-            <Label>
-                Password
-                <Input />
-            </Label>
-        </Form>
-    ),
+    render: ({ size, variant }) => {
+        const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+            event.preventDefault()
+        }
+
+        return (
+            <Form size={size} variant={variant} onSubmit={handleSubmit}>
+                <Label htmlFor="username">
+                    Username
+                    <Input name="username" id="username" placeholder="johndoe" />
+                </Label>
+                <Label htmlFor="password">
+                    Password
+                    <Input name="password" id="password" type="password" placeholder="******" />
+                </Label>
+                <Submit className="mt-2" fullWidth value="Login" />
+            </Form>
+        )
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement)
+        const username = canvas.getByPlaceholderText("johndoe")
+        await userEvent.type(username, "halvaradop", { delay: 102 })
+        await expect(username).toHaveValue("halvaradop")
+
+        const password = canvas.getByPlaceholderText("******")
+        await userEvent.type(password, "halvaradop", { delay: 102 })
+        await expect(password).toHaveValue("halvaradop")
+
+        await userEvent.click(canvas.getByText("Login"))
+
+        await userEvent.clear(username)
+        await userEvent.clear(password)
+        await expect(username).toHaveValue("")
+        await expect(password).toHaveValue("")
+    },
 }
 
 export default meta

--- a/packages/ui-input/src/input.stories.tsx
+++ b/packages/ui-input/src/input.stories.tsx
@@ -1,5 +1,6 @@
-import { Input } from "./index.jsx"
 import type { ArgTypes, Meta, StoryObj } from "@storybook/react"
+import { expect, userEvent, within } from "@storybook/test"
+import { Input } from "./index.jsx"
 import { decorator } from "@halvaradop/ui-utils/decorator"
 import { DocsPage } from "@halvaradop/ui-utils/docs-page"
 
@@ -80,6 +81,14 @@ const meta: Meta = {
         },
     },
     decorators: [decorator],
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement)
+        const inputs = canvas.getAllByRole("textbox")
+        for (const input of inputs) {
+            await userEvent.type(input, "John Doe", { delay: 102 })
+            expect(input).toHaveValue("John Doe")
+        }
+    },
 } satisfies Meta<typeof Input>
 
 type Story = StoryObj<typeof meta>

--- a/packages/ui-radio-group/src/radio-group.stories.tsx
+++ b/packages/ui-radio-group/src/radio-group.stories.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react"
 import type { Meta, StoryObj } from "@storybook/react"
+import { expect, userEvent, within } from "@storybook/test"
 import { RadioGroup, Radio } from "./index.js"
 import { Label } from "@/ui/ui-label/src/index.js"
 import { decorator } from "@halvaradop/ui-utils/decorator"
@@ -67,11 +68,25 @@ export const Base: Story = {
             </RadioGroup>
         )
     },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement)
+        const radioGroup = canvas.getByRole("group")
+        const radio1 = within(radioGroup).getByLabelText("Pizza")
+        const radio2 = within(radioGroup).getByLabelText("Hamburger")
+
+        await userEvent.click(radio1)
+        expect(radio1).toBeChecked()
+        expect(radio2).not.toBeChecked()
+
+        await userEvent.click(radio2)
+        expect(radio2).toBeChecked()
+        expect(radio1).not.toBeChecked()
+    },
 }
 
 export const DefaultChecked: Story = {
-    render: () => (
-        <RadioGroup name="food-3" defaultValue="pizza">
+    render: ({ variant }) => (
+        <RadioGroup name="food-3" defaultValue="pizza" variant={variant}>
             <Label className="flex items-center gap-x-2">
                 <Radio value="pizza" name="food-3" />
                 Pizza

--- a/packages/ui-select/src/select.stories.tsx
+++ b/packages/ui-select/src/select.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react"
+import { within, expect } from "@storybook/test"
 import { Select, SelectList, SelectOption, SelectTrigger } from "./index.js"
 import { decorator } from "@halvaradop/ui-utils/decorator"
 import { DocsPage } from "@halvaradop/ui-utils/docs-page"
@@ -31,13 +32,35 @@ export const Base: Story = {
             <SelectList>
                 <SelectOption value="pizza">Pizza</SelectOption>
                 <SelectOption value="burger">Burger</SelectOption>
-                <SelectOption value="sushi" aria-disabled>
-                    Sushi
-                </SelectOption>
+                <SelectOption value="sushi">Sushi</SelectOption>
                 <SelectOption value="salad">Salad</SelectOption>
             </SelectList>
         </Select>
     ),
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement)
+        const select = await canvas.findByText("Select an item")
+        await expect(select).toBeInTheDocument()
+
+        select.focus()
+        select.click()
+
+        const sushi = await canvas.findByText("Sushi")
+        const burger = await canvas.findByText("Burger")
+        await expect(sushi).toBeInTheDocument()
+        await expect(burger).toBeInTheDocument()
+        await expect(await canvas.findByText("Pizza")).toBeInTheDocument()
+        await expect(await canvas.findByText("Salad")).toBeInTheDocument()
+        sushi.click()
+
+        await expect(sushi).toBeInTheDocument()
+        await expect(canvas.queryByText("Select an item")).not.toBeInTheDocument()
+
+        burger.click()
+        await expect(burger).toBeInTheDocument()
+        await expect(burger).toHaveAttribute("aria-selected", "true")
+        await expect(sushi).not.toHaveAttribute("aria-selected", "true")
+    },
 }
 
 export default meta

--- a/packages/ui-submit/src/submit.stories.tsx
+++ b/packages/ui-submit/src/submit.stories.tsx
@@ -1,5 +1,5 @@
-"use client"
 import type { ArgTypes, Meta, StoryObj } from "@storybook/react"
+import { expect, getAllByRole, userEvent, within } from "@storybook/test"
 import { Submit } from "./index.js"
 import { decorator } from "@halvaradop/ui-utils/decorator"
 import { DocsPage } from "@halvaradop/ui-utils/docs-page"
@@ -67,6 +67,18 @@ const meta: Meta = {
         },
     },
     decorators: [decorator],
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement)
+        const buttons = canvas.getAllByRole("button")
+        for (const button of buttons.slice(1)) {
+            await expect(button).toBeInTheDocument()
+            button.setAttribute("disabled", "true")
+            await expect(button).toBeDisabled()
+            await new Promise((resolve) => setTimeout(resolve, 500))
+            button.removeAttribute("disabled")
+            await expect(button).not.toBeDisabled()
+        }
+    },
 } satisfies Meta<typeof Submit>
 
 type Story = StoryObj<typeof meta>


### PR DESCRIPTION


## Description

This pull request adds `play` functions to the Storybook stories for several components provided by the `@halvaradop/ui` library. The purpose of these `play` functions is to simulate user interactions such as `focus`, `tab`, `hover`, `click`, and other event-driven behaviors. These simulations improve interactivity in the component stories and aid in automated behavior testing. These changes were retrived from the pull request #154.

> [!Note]
> Only the aforementioned changes have been synchronized from the master branch to the beta branch. This pull request was created to minimize potential issues during synchronization.

<!--Provide a detailed description or reasoning for the changes made -->

## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
