### PR TITLE
feat(tsup): add "use client" directive as a banner

### DIFF
--- a/packages/ui-utils/src/tsup.config.base.ts
+++ b/packages/ui-utils/src/tsup.config.base.ts
@@ -14,4 +14,7 @@ export const tsupConfig: Options = {
     minify: env === "production",
     bundle: env === "production",
     external: ["vite", "tailwindcss", "react", "react-dom"],
+    banner: {
+        js: `"use client"`,
+    },
 }


### PR DESCRIPTION

## Description

This pull request updates the `tsupConfig` exported from `@halvaradop/ui-utils` package of the monorepo to add the `"use client"` directive as a banner for all of the packages provided by the library. The cause of this new update is due to the Next.js application required of the Client Components use the "use client" directive to tells to the compiler that the file should be treated as a Client Component and not as a Server Component and that directive is required for that components that use React hooks to manage the state of something else.

This new introduce was added for the open issues #145 which explains the current problem.

<!--Provide a detailed description or reasoning for the changes made -->

## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
