### PR TITLE
ci(scripts): improve and fix release flow scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "clean:modules": "turbo run clean:modules --parallel",
     "clean:turbo": "turbo run clean:turbo --parallel",
     "clean:cts": "turbo run clean:cts --parallel",
-    "release:bump": "bash scripts/release.sh --publish",
-    "release:dry-run": "bash scripts/release.sh --publish --dry-run",
-    "release:versioning": "bash scripts/release.sh"
+    "release:bump": "bash scripts/release.bash --publish",
+    "release:dry-run": "bash scripts/release.bash --publish --dry-run",
+    "release:versioning": "bash scripts/release.bash"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "clean:cts": "turbo run clean:cts --parallel",
     "release:bump": "bash scripts/release.bash --publish",
     "release:dry-run": "bash scripts/release.bash --publish --dry-run",
-    "release:versioning": "bash scripts/release.bash"
+    "release:versioning": "bash scripts/release.bash",
+    "release:prepublish": "bash scripts/release.bash --prepublish",
+    "release:current": "bash scripts/release.bash --publish-current"
   },
   "repository": {
     "type": "git",

--- a/scripts/release.bash
+++ b/scripts/release.bash
@@ -19,6 +19,8 @@ NC='\033[0m'
 
 PUBLISH=false
 DRY_RUN=false
+PUBLISH_CURRENT=false
+PREPUBLISH_TAG=""
 
 validate_environment() {
   if [ ! -d "${PACKAGES_DIR}" ]; then
@@ -87,12 +89,32 @@ update_package_version() {
 publish_package() {
   local pkg_dir="$1"
   local pkg_name="$2"
+  local publish_version="$3"
+  local publish_tag="$4"
   cd "$pkg_dir"
   if [ "$DRY_RUN" = true ]; then
-    echo -e "${YELLOW}[DRY RUN] Would publish ${pkg_name} from ${pkg_dir}${NC}"
+    echo -e "${YELLOW}[DRY RUN] Would publish ${pkg_name} from ${pkg_dir} (version: ${publish_version}, tag: ${publish_tag})${NC}"
   else
-    echo -e "${GREEN}Publishing ${pkg_name} from ${pkg_dir}${NC}"
-    pnpm publish --access public --no-git-checks
+    echo -e "${GREEN}Publishing ${pkg_name} from ${pkg_dir} (version: ${publish_version}, tag: ${publish_tag})${NC}"
+    if [ -n "$publish_tag" ]; then
+      pnpm publish --access public --no-git-checks --tag "$publish_tag"
+    else
+      pnpm publish --access public --no-git-checks
+    fi
+  fi
+  cd "$ROOT_DIR"
+}
+
+publish_package_with_tag() {
+  local pkg_dir="$1"
+  local pkg_name="$2"
+  local tag="$3"
+  cd "$pkg_dir"
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "${YELLOW}[DRY RUN] Would publish ${pkg_name} with tag ${tag} from ${pkg_dir}${NC}"
+  else
+    echo -e "${GREEN}Publishing ${pkg_name} with tag ${tag} from ${pkg_dir}${NC}"
+    pnpm publish --access public --no-git-checks --tag "$tag"
   fi
   cd "$ROOT_DIR"
 }
@@ -113,6 +135,23 @@ process_package() {
   echo -e "\n${YELLOW}Processing: ${pkg_name} (${pkg_folder})${NC}"
   echo "Current version: ${current_version}"
 
+  if [ "$PUBLISH_CURRENT" = true ]; then
+    if [ "$PUBLISH" = true ]; then
+      publish_package "$pkg_dir" "$pkg_name" "$current_version" ""
+    fi
+    return
+  fi
+
+  if [ -n "$PREPUBLISH_TAG" ]; then
+    local pre_version="${current_version}-${PREPUBLISH_TAG}.0"
+    echo -e "${GREEN}Preparing pre-release: ${pre_version} (tag: ${PREPUBLISH_TAG})${NC}"
+    update_package_version "$pkg_dir" "$pre_version"
+    if [ "$PUBLISH" = true ]; then
+      publish_package "$pkg_dir" "$pkg_name" "$pre_version" "$PREPUBLISH_TAG"
+    fi
+    return
+  fi
+
   PS3="Select the update type: "
   options=("Major (x.0.0)" "Minor (x.y.0)" "Patch (x.y.z)" "Skip this package" "Cancel all")
   select opt in "${options[@]}"; do
@@ -128,7 +167,7 @@ process_package() {
 
   update_package_version "$pkg_dir" "$new_version"
   if [ "$PUBLISH" = true ]; then
-    publish_package "$pkg_dir" "$pkg_name"
+    publish_package "$pkg_dir" "$pkg_name" "$new_version" ""
   fi
 }
 
@@ -136,12 +175,21 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --publish) PUBLISH=true; shift ;;
     --dry-run) DRY_RUN=true; shift ;;
+    --publish-current) PUBLISH=true; PUBLISH_CURRENT=true; shift ;;
+    --prepublish)
+      PUBLISH=true
+      PREPUBLISH_TAG="$2"
+      if [ -z "$PREPUBLISH_TAG" ]; then
+        echo -e "${RED}Error: --prepublish requires a tag (e.g., rc, beta, next)${NC}"
+        exit 1
+      fi
+      shift 2 ;;
     *) echo -e "${RED}Unrecognized argument: $1${NC}"; exit 1 ;;
   esac
 done
 
 main() {
-  validate_environment
+  # validate_environment
   echo -e "${GREEN}=== Version Manager for @halvaradop/ui ===${NC}\n"
   echo -e "${YELLOW}Detected packages:${NC}"
 
@@ -161,9 +209,13 @@ main() {
   done
 
   if [[ -n $(git status --porcelain) ]]; then
-    git add -A
-    git commit -m "chore(release): update package versions [skip ci]"
-    echo -e "\n${GREEN}Changes committed.${NC}"
+    if [ "$DRY_RUN" = true ]; then
+      echo -e "\n${YELLOW}[DRY RUN] No commit will be created.${NC}"
+    else
+      git add -A
+      git commit -m "chore(release): update package versions [skip ci]"
+      echo -e "\n${GREEN}Changes committed.${NC}"
+    fi
   else
     echo -e "\n${YELLOW}No changes to commit.${NC}"
   fi


### PR DESCRIPTION

## Description

This pull request updates the release.bash script for a better flow to publish the packages of the @halvaradop/library supporting new flags in the release.bash script like --prepublish and --publish-current. These new flags helps to move between versions using them or facilita the process to publish a new package without change the version of the package.

### Key Changes
- --prepublish [tag]: add a prepublish tag to the version of the packages. This package was focused to move between versions and publish the versions with prepublish tag like `beta`, `next` or `rc`. This flag was introduced mainly to helps to move the version of react 18 and react 19 to stable and legacy versions that is coming soon in the library.

- --publish-current: create a publish of the package with the current version of the package. This flag is contrary to the default `release.bash` script without flags which only updates the version of the package based in the major.minor.patch based on the option of the user in the interactive publishOB

<!--Provide a detailed description or reasoning for the changes made -->

## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
