### PR TITLE
build(tsconfig): extend from `tsconfig.base.json`

### DIFF
--- a/packages/ui-utils/tsconfig.base.json
+++ b/packages/ui-utils/tsconfig.base.json
@@ -2,7 +2,7 @@
   "display": "Node 20",
   "_version": "20.1.0",
   "compilerOptions": {
-    "lib": ["ES2023", "DOM"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "target": "ES2020",
     "module": "Node16",
     "moduleResolution": "Node16",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,23 +1,6 @@
 {
+  "extends": "./packages/ui-utils/tsconfig.base.json",
   "compilerOptions": {
-    "esModuleInterop": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "target": "ES2020",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "moduleDetection": "force",
-    "declaration": true,
-    "sourceMap": true,
-    "declarationMap": true,
-    "strict": true,
-    "allowJs": true,
-    "checkJs": true,
-    "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "isolatedModules": true,
-    "composite": true,
     "baseUrl": ".",
     "paths": {
       "@/ui/*": ["./packages/*"]


### PR DESCRIPTION

## Description

This pull request updates the `tsconfig.base.json` file at the root of the repository to extend from the `ui-utils/tsconfig.base.json` configuration. The goal is to centralize and standardize the TypeScript configuration used across all packages within the monorepo.

By extending from a shared configuration, we ensure consistency, reduce duplication, and simplify future updates to the TypeScript setup. This change aligns all packages with a unified base configuration maintained in `@halvaradop/ui-utils`.

## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
