### PR TITLE
[SYNC] ci(scripts): add `release.bash` script for releasing packages

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,6 +16,7 @@ ui/
 │   ├── ui-slot/          # Slot component (decoupled from ui-core)
 │   ├── ui-template/      # Boilerplate for new components
 │   └── ...               # More UI packages
+├── scripts/              # Utility scripts (e.g., build, release)
 ├── tests/                # E2E tests using Playwright
 ├── tailwind.css          # CSS theme and variable declarations
 ├── turbo.json            # Turborepo config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ Per-package version history is maintained inside each package’s own `CHANGELOG
 
 ---
 
+## [Unreleased]
+
+## [rc pre-release] - 2025-06-07
+
+- Pre-release (`rc`) versions published for all major monorepo packages [#170](https://github.com/halvaradop/ui/pull/170):
+
+  - @halvaradop/ui-button
+  - @halvaradop/ui-checkbox
+  - @halvaradop/ui-core
+  - @halvaradop/ui-dialog
+  - @halvaradop/ui-form
+  - @halvaradop/ui-input
+  - @halvaradop/ui-label
+  - @halvaradop/ui-radio-group
+  - @halvaradop/ui-radio
+  - @halvaradop/ui-select
+  - @halvaradop/ui-slot
+  - @halvaradop/ui-submit
+  - @halvaradop/ui-template
+  - @halvaradop/ui-utils
+
+  Each package incremented its pre-release version (`rc.0`, `rc.1`, etc.) as appropriate. These versions are available on npm under the `rc` tag for testing and validation prior to the stable release.
+
+---
+
+---
+
 ## Added
 
 - **Theming system with CSS variables**  
@@ -60,8 +87,6 @@ Per-package version history is maintained inside each package’s own `CHANGELOG
 - **Legacy configuration files**  
   Removed duplicated config files (`tsup.config.base.ts`, `tsconfig.base.json`, etc.) from each package. These were replaced by the centralized `@halvaradop/ui-utils` package.  
   → [PR #107](https://github.com/halvaradop/ui/pull/107)
-
----
 
 ## Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,14 +168,15 @@ Each package follows [Semantic Versioning](https://semver.org/) independently:
 - MINOR: New features
 - PATCH: Fixes
 
-> Note: We do **not** use Changesets. All changelogs are manually written before each release.
+> [!NOTE]
+> We do **not** use Changesets. All changelogs are maintained manually and must be updated before each release. Releases are managed using the `release` script located in the `scripts` folder, which provides an interactive bash workflow for publishing new versions.
 
-### Publishing (maintainers only)
+### Publishing (Maintainers Only)
 
-1. Update `CHANGELOG.md` for each modified package
-2. Bump `version` in `package.json`
-3. Create a GitHub release
-4. Publish to npm manually or via script
+1. Update the `CHANGELOG.md` for each modified package.
+2. Bump the `version` field in each relevant `package.json`.
+3. Create a GitHub release.
+4. Publish to npm by running the `release.bash` script, or use the direct scripts: `release:bump`, `release:dry-run`, or `release:versioning` via the package manager (`pnpm`).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
     "clean:modules": "turbo run clean:modules --parallel",
     "clean:turbo": "turbo run clean:turbo --parallel",
     "clean:cts": "turbo run clean:cts --parallel",
-    "release:bump": "bash scripts/release.sh --publish",
-    "release:dry-run": "bash scripts/release.sh --publish --dry-run",
-    "release:versioning": "bash scripts/release.sh"
+    "release:bump": "bash scripts/release.bash --publish",
+    "release:dry-run": "bash scripts/release.bash --publish --dry-run",
+    "release:versioning": "bash scripts/release.bash",
+    "release:prepublish": "bash scripts/release.bash --prepublish",
+    "release:current": "bash scripts/release.bash --publish-current"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "clean:dist": "turbo run clean:dist --parallel",
     "clean:modules": "turbo run clean:modules --parallel",
     "clean:turbo": "turbo run clean:turbo --parallel",
-    "clean:cts": "turbo run clean:cts --parallel"
+    "clean:cts": "turbo run clean:cts --parallel",
+    "release:bump": "bash scripts/release.sh --publish",
+    "release:dry-run": "bash scripts/release.sh --publish --dry-run",
+    "release:versioning": "bash scripts/release.sh"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-button/CHANGELOG.md
+++ b/packages/ui-button/CHANGELOG.md
@@ -21,6 +21,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.6.0-rc.1] - 2025-06-07
+
+### Notes
+
+- This is a **release candidate** published under the `rc` tag to validate changes in preparation for the upcoming `1.0.0` major release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- Versioning and publishing were automated using the `release.bash` script.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- The purpose of this release is to test the release workflow in real environments before finalizing the stable release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+
+> No breaking changes have been introduced in this release candidate.  
+> The final release will follow after successful validation.
+
+This release was initiated based on [#169](https://github.com/halvaradop/ui/issues/169), which outlines the reasoning for upgrading to a stable major version.
+
+---
+
 ## [0.6.0] - 2025-02-06
 
 ### Added

--- a/packages/ui-checkbox/CHANGELOG.md
+++ b/packages/ui-checkbox/CHANGELOG.md
@@ -26,6 +26,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.0-rc.1] - 2025-06-07
+
+### Notes
+
+- This is a **release candidate** published under the `rc` tag to validate changes in preparation for the upcoming `1.0.0` major release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- Versioning and publishing were automated using the `release.bash` script.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- The purpose of this release is to test the release workflow in real environments before finalizing the stable release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+
+> No breaking changes have been introduced in this release candidate.  
+> The final release will follow after successful validation.
+
+This release was initiated based on [#169](https://github.com/halvaradop/ui/issues/169), which outlines the reasoning for upgrading to a stable major version.
+
+---
+
 ## [0.4.0] - 2025-02-06
 
 ### Added

--- a/packages/ui-core/CHANGELOG.md
+++ b/packages/ui-core/CHANGELOG.md
@@ -21,6 +21,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.0-rc.1] - 2025-06-07
+
+### Notes
+
+- This is a **release candidate** published under the `rc` tag to validate changes in preparation for the upcoming `1.0.0` major release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- Versioning and publishing were automated using the `release.bash` script.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- The purpose of this release is to test the release workflow in real environments before finalizing the stable release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+
+> No breaking changes have been introduced in this release candidate.  
+> The final release will follow after successful validation.
+
+This release was initiated based on [#169](https://github.com/halvaradop/ui/issues/169), which outlines the reasoning for upgrading to a stable major version.
+
+---
+
 ## [0.5.0] - 2025-02-06
 
 ### Removed

--- a/packages/ui-dialog/CHANGELOG.md
+++ b/packages/ui-dialog/CHANGELOG.md
@@ -21,6 +21,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.0-rc.1] - 2025-06-07
+
+### Notes
+
+- This is a **release candidate** published under the `rc` tag to validate changes in preparation for the upcoming `1.0.0` major release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- Versioning and publishing were automated using the `release.bash` script.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- The purpose of this release is to test the release workflow in real environments before finalizing the stable release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+
+> No breaking changes have been introduced in this release candidate.  
+> The final release will follow after successful validation.
+
+This release was initiated based on [#169](https://github.com/halvaradop/ui/issues/169), which outlines the reasoning for upgrading to a stable major version.
+
+---
+
 ## [0.5.0] - 2025-03-19
 
 ### Changed

--- a/packages/ui-form/CHANGELOG.md
+++ b/packages/ui-form/CHANGELOG.md
@@ -21,6 +21,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.0-rc.1] - 2025-06-07
+
+### Notes
+
+- This is a **release candidate** published under the `rc` tag to validate changes in preparation for the upcoming `1.0.0` major release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- Versioning and publishing were automated using the `release.bash` script.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- The purpose of this release is to test the release workflow in real environments before finalizing the stable release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+
+> No breaking changes have been introduced in this release candidate.  
+> The final release will follow after successful validation.
+
+This release was initiated based on [#169](https://github.com/halvaradop/ui/issues/169), which outlines the reasoning for upgrading to a stable major version.
+
+---
+
 ## [0.4.0] - 2025-02-06
 
 ### Added

--- a/packages/ui-input/CHANGElOG.md
+++ b/packages/ui-input/CHANGElOG.md
@@ -21,6 +21,24 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.5.0-rc.1] - 2025-06-07
+
+### Notes
+
+- This is a **release candidate** published under the `rc` tag to validate changes in preparation for the upcoming `1.0.0` major release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- Versioning and publishing were automated using the `release.bash` script.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- The purpose of this release is to test the release workflow in real environments before finalizing the stable release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+
+> No breaking changes have been introduced in this release candidate.  
+> The final release will follow after successful validation.
+
+This release was initiated based on [#169](https://github.com/halvaradop/ui/issues/169), which outlines the reasoning for upgrading to a stable major version.
+
+---
+
 ## [0.5.0] - 2025-02-06
 
 ### Added

--- a/packages/ui-label/CHANGELOG.md
+++ b/packages/ui-label/CHANGELOG.md
@@ -25,6 +25,24 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.4.0-rc.1] - 2025-06-07
+
+### Notes
+
+- This is a **release candidate** published under the `rc` tag to validate changes in preparation for the upcoming `1.0.0` major release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- Versioning and publishing were automated using the `release.bash` script.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- The purpose of this release is to test the release workflow in real environments before finalizing the stable release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+
+> No breaking changes have been introduced in this release candidate.  
+> The final release will follow after successful validation.
+
+This release was initiated based on [#169](https://github.com/halvaradop/ui/issues/169), which outlines the reasoning for upgrading to a stable major version.
+
+---
+
 ## [0.4.0] - 2025-02-06
 
 ### Added

--- a/packages/ui-radio-group/CHANGELOG.md
+++ b/packages/ui-radio-group/CHANGELOG.md
@@ -22,6 +22,24 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.3.3-rc.1] - 2025-06-07
+
+### Notes
+
+- This is a **release candidate** published under the `rc` tag to validate changes in preparation for the upcoming `1.0.0` major release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- Versioning and publishing were automated using the `release.bash` script.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- The purpose of this release is to test the release workflow in real environments before finalizing the stable release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+
+> No breaking changes have been introduced in this release candidate.  
+> The final release will follow after successful validation.
+
+This release was initiated based on [#169](https://github.com/halvaradop/ui/issues/169), which outlines the reasoning for upgrading to a stable major version.
+
+---
+
 ## [0.3.0] - 2025-03-19
 
 ### Added

--- a/packages/ui-radio-group/package.json
+++ b/packages/ui-radio-group/package.json
@@ -61,7 +61,6 @@
   },
   "dependencies": {
     "@halvaradop/ui-core": "workspace:*",
-    "@halvaradop/ui-radio": "workspace:*",
     "class-variance-authority": "0.7.0"
   },
   "devDependencies": {

--- a/packages/ui-radio/package.json
+++ b/packages/ui-radio/package.json
@@ -47,7 +47,7 @@
     }
   },
   "dependencies": {
-    "@halvaradop/ui-core": "workspace:*",
+    "@halvaradop/ui-core": "^0.5.0-rc.0",
     "class-variance-authority": "0.7.0"
   },
   "devDependencies": {

--- a/packages/ui-select/CHANGELOG.md
+++ b/packages/ui-select/CHANGELOG.md
@@ -19,6 +19,42 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.1.0-rc.1] - 2025-06-07
+
+### Notes
+
+- This is a **release candidate** published under the `rc` tag to validate changes in preparation for the upcoming `1.0.0` major release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- Versioning and publishing were automated using the `release.bash` script.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- The purpose of this release is to test the release workflow in real environments before finalizing the stable release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+
+> No breaking changes have been introduced in this release candidate.  
+> The final release will follow after successful validation.
+
+This release was initiated based on [#169](https://github.com/halvaradop/ui/issues/169), which outlines the reasoning for upgrading to a stable major version.
+
+---
+
+## [0.1.0-rc.1] - 2025-06-07
+
+### Notes
+
+- This is a **release candidate** published under the `rc` tag to validate changes in preparation for the upcoming `1.0.0` major release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- Versioning and publishing were automated using the `release.bash` script.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- The purpose of this release is to test the release workflow in real environments before finalizing the stable release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+
+> No breaking changes have been introduced in this release candidate.  
+> The final release will follow after successful validation.
+
+This release was initiated based on [#169](https://github.com/halvaradop/ui/issues/169), which outlines the reasoning for upgrading to a stable major version.
+
+---
+
 ## [0.1.0] - 2025-04-06
 
 ### Added

--- a/packages/ui-slot/CHANGELOG.md
+++ b/packages/ui-slot/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 This changelog follows the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format  
 and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-rc.1] - 2025-06-07
+
+### Notes
+
+- This is a **release candidate** published under the `rc` tag to validate changes in preparation for the upcoming `1.0.0` major release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- Versioning and publishing were automated using the `release.bash` script.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- The purpose of this release is to test the release workflow in real environments before finalizing the stable release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+
+> No breaking changes have been introduced in this release candidate.  
+> The final release will follow after successful validation.
+
+This release was initiated based on [#169](https://github.com/halvaradop/ui/issues/169), which outlines the reasoning for upgrading to a stable major version.
+
+---
+
 ## [0.1.0] - 2025-05-07
 
 ### Added

--- a/packages/ui-submit/CHANGELOG.md
+++ b/packages/ui-submit/CHANGELOG.md
@@ -21,6 +21,24 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.4.0-rc.1] - 2025-06-07
+
+### Notes
+
+- This is a **release candidate** published under the `rc` tag to validate changes in preparation for the upcoming `1.0.0` major release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- Versioning and publishing were automated using the `release.bash` script.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+- The purpose of this release is to test the release workflow in real environments before finalizing the stable release.  
+  See [#170](https://github.com/halvaradop/ui/pull/170)
+
+> No breaking changes have been introduced in this release candidate.  
+> The final release will follow after successful validation.
+
+This release was initiated based on [#169](https://github.com/halvaradop/ui/issues/169), which outlines the reasoning for upgrading to a stable major version.
+
+---
+
 ## [0.3.0] - 2025-02-06
 
 ### Added

--- a/packages/ui-template/CHANGELOG.md
+++ b/packages/ui-template/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - Date
-
 ### Addedd
 
 ### Fixed

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 1.52.0
       '@storybook/addon-essentials':
         specifier: ^8.6.4
-        version: 8.6.14(@types/react@19.1.5)(storybook@8.6.14(prettier@3.5.3))
+        version: 8.6.14(@types/react@19.1.6)(storybook@8.6.14(prettier@3.5.3))
       '@storybook/addon-interactions':
         specifier: ^8.6.4
         version: 8.6.14(storybook@8.6.14(prettier@3.5.3))
@@ -40,7 +40,7 @@ importers:
         version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.14(prettier@3.5.3))(typescript@5.8.3)
       '@storybook/react-vite':
         specifier: ^8.6.12
-        version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.41.1)(storybook@8.6.14(prettier@3.5.3))(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
+        version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.41.1)(storybook@8.6.14(prettier@3.5.3))(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1))
       '@storybook/test':
         specifier: ^8.6.4
         version: 8.6.14(storybook@8.6.14(prettier@3.5.3))
@@ -49,19 +49,19 @@ importers:
         version: 4.1.7
       '@tailwindcss/vite':
         specifier: ^4.1.6
-        version: 4.1.7(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
+        version: 4.1.7(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1))
       '@types/node':
         specifier: ^22.13.10
         version: 22.15.21
       '@types/react':
         specifier: ^19.0.2
-        version: 19.1.5
+        version: 19.1.6
       '@types/react-dom':
         specifier: ^19.0.2
-        version: 19.1.5(@types/react@19.1.5)
+        version: 19.1.6(@types/react@19.1.6)
       '@vitejs/plugin-react-swc':
         specifier: ^3.8.0
-        version: 3.10.0(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
+        version: 3.10.0(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1))
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.3)
@@ -85,7 +85,7 @@ importers:
         version: 4.1.7
       tsup:
         specifier: ^8.4.0
-        version: 8.5.0(@swc/core@1.11.29)(jiti@2.4.2)(postcss@8.5.3)(typescript@5.8.3)(yaml@2.8.0)
+        version: 8.5.0(@swc/core@1.11.29)(jiti@2.4.2)(postcss@8.5.3)(typescript@5.8.3)
       turbo:
         specifier: ^2.4.4
         version: 2.5.3
@@ -94,7 +94,7 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
+        version: 6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)
 
   packages/ui-button:
     dependencies:
@@ -238,8 +238,8 @@ importers:
   packages/ui-radio:
     dependencies:
       '@halvaradop/ui-core':
-        specifier: workspace:*
-        version: link:../ui-core
+        specifier: ^0.5.0-rc.0
+        version: 0.5.0
       class-variance-authority:
         specifier: 0.7.0
         version: 0.7.0
@@ -259,9 +259,6 @@ importers:
       '@halvaradop/ui-core':
         specifier: workspace:*
         version: link:../ui-core
-      '@halvaradop/ui-radio':
-        specifier: workspace:*
-        version: link:../ui-radio
       class-variance-authority:
         specifier: 0.7.0
         version: 0.7.0
@@ -577,6 +574,9 @@ packages:
 
   '@halvaradop/ui-core@0.3.0':
     resolution: {integrity: sha512-Ev9g9A5Op4JLRVXiWd/LD8lZw9Iy+D+3CjB/DqnQ0mSgV2FsiBqHE153keqT2vrXYMG/be0qpsteFmutL47skA==}
+
+  '@halvaradop/ui-core@0.5.0':
+    resolution: {integrity: sha512-r0vNex3PTD6OUlmXGMA8sXrkdKAVV0wbZ7uMpzhJ/moy3OHNt3tQdgsbTHLdN3fWTaagxLvu+FuYw1edeXNh6Q==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -1134,13 +1134,13 @@ packages:
   '@types/node@22.15.21':
     resolution: {integrity: sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==}
 
-  '@types/react-dom@19.1.5':
-    resolution: {integrity: sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==}
+  '@types/react-dom@19.1.6':
+    resolution: {integrity: sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==}
     peerDependencies:
       '@types/react': ^19.0.0
 
-  '@types/react@19.1.5':
-    resolution: {integrity: sha512-piErsCVVbpMMT2r7wbawdZsq4xMvIAhQuac2gedQHysu1TZYEigE6pnFfgZT+/jQnrRuF5r+SHzuehFjfRjr4g==}
+  '@types/react@19.1.6':
+    resolution: {integrity: sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==}
 
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
@@ -2291,11 +2291,6 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
-  yaml@2.8.0:
-    resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -2507,6 +2502,10 @@ snapshots:
     dependencies:
       tailwind-merge: 2.6.0
 
+  '@halvaradop/ui-core@0.5.0':
+    dependencies:
+      tailwind-merge: 2.6.0
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -2520,12 +2519,12 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1))':
     dependencies:
       glob: 10.4.5
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.8.3)
-      vite: 6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)
     optionalDependencies:
       typescript: 5.8.3
 
@@ -2546,11 +2545,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@mdx-js/react@3.1.0(@types/react@19.1.5)(react@18.3.1)':
+  '@mdx-js/react@3.1.0(@types/react@19.1.6)(react@19.0.0)':
     dependencies:
       '@types/mdx': 2.0.13
-      '@types/react': 19.1.5
-      react: 18.3.1
+      '@types/react': 19.1.6
+      react: 19.0.0
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -2652,25 +2651,25 @@ snapshots:
       storybook: 8.6.14(prettier@3.5.3)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-docs@8.6.14(@types/react@19.1.5)(storybook@8.6.14(prettier@3.5.3))':
+  '@storybook/addon-docs@8.6.14(@types/react@19.1.6)(storybook@8.6.14(prettier@3.5.3))':
     dependencies:
-      '@mdx-js/react': 3.1.0(@types/react@19.1.5)(react@18.3.1)
-      '@storybook/blocks': 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.5.3))
+      '@mdx-js/react': 3.1.0(@types/react@19.1.6)(react@19.0.0)
+      '@storybook/blocks': 8.6.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.14(prettier@3.5.3))
       '@storybook/csf-plugin': 8.6.14(storybook@8.6.14(prettier@3.5.3))
-      '@storybook/react-dom-shim': 8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.5.3))
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      '@storybook/react-dom-shim': 8.6.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.14(prettier@3.5.3))
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
       storybook: 8.6.14(prettier@3.5.3)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-essentials@8.6.14(@types/react@19.1.5)(storybook@8.6.14(prettier@3.5.3))':
+  '@storybook/addon-essentials@8.6.14(@types/react@19.1.6)(storybook@8.6.14(prettier@3.5.3))':
     dependencies:
       '@storybook/addon-actions': 8.6.14(storybook@8.6.14(prettier@3.5.3))
       '@storybook/addon-backgrounds': 8.6.14(storybook@8.6.14(prettier@3.5.3))
       '@storybook/addon-controls': 8.6.14(storybook@8.6.14(prettier@3.5.3))
-      '@storybook/addon-docs': 8.6.14(@types/react@19.1.5)(storybook@8.6.14(prettier@3.5.3))
+      '@storybook/addon-docs': 8.6.14(@types/react@19.1.6)(storybook@8.6.14(prettier@3.5.3))
       '@storybook/addon-highlight': 8.6.14(storybook@8.6.14(prettier@3.5.3))
       '@storybook/addon-measure': 8.6.14(storybook@8.6.14(prettier@3.5.3))
       '@storybook/addon-outline': 8.6.14(storybook@8.6.14(prettier@3.5.3))
@@ -2735,15 +2734,6 @@ snapshots:
       memoizerific: 1.11.3
       storybook: 8.6.14(prettier@3.5.3)
 
-  '@storybook/blocks@8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.5.3))':
-    dependencies:
-      '@storybook/icons': 1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      storybook: 8.6.14(prettier@3.5.3)
-      ts-dedent: 2.2.0
-    optionalDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
   '@storybook/blocks@8.6.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.14(prettier@3.5.3))':
     dependencies:
       '@storybook/icons': 1.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -2753,13 +2743,13 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  '@storybook/builder-vite@8.6.14(storybook@8.6.14(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))':
+  '@storybook/builder-vite@8.6.14(storybook@8.6.14(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1))':
     dependencies:
       '@storybook/csf-plugin': 8.6.14(storybook@8.6.14(prettier@3.5.3))
       browser-assert: 1.2.1
       storybook: 8.6.14(prettier@3.5.3)
       ts-dedent: 2.2.0
-      vite: 6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)
 
   '@storybook/components@8.6.14(storybook@8.6.14(prettier@3.5.3))':
     dependencies:
@@ -2793,11 +2783,6 @@ snapshots:
 
   '@storybook/global@5.0.0': {}
 
-  '@storybook/icons@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
   '@storybook/icons@1.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       react: 19.0.0
@@ -2817,23 +2802,17 @@ snapshots:
     dependencies:
       storybook: 8.6.14(prettier@3.5.3)
 
-  '@storybook/react-dom-shim@8.6.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14(prettier@3.5.3))':
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.6.14(prettier@3.5.3)
-
   '@storybook/react-dom-shim@8.6.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.14(prettier@3.5.3))':
     dependencies:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       storybook: 8.6.14(prettier@3.5.3)
 
-  '@storybook/react-vite@8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.41.1)(storybook@8.6.14(prettier@3.5.3))(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))':
+  '@storybook/react-vite@8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.41.1)(storybook@8.6.14(prettier@3.5.3))(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1))
       '@rollup/pluginutils': 5.1.4(rollup@4.41.1)
-      '@storybook/builder-vite': 8.6.14(storybook@8.6.14(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
+      '@storybook/builder-vite': 8.6.14(storybook@8.6.14(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1))
       '@storybook/react': 8.6.14(@storybook/test@8.6.14(storybook@8.6.14(prettier@3.5.3)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.6.14(prettier@3.5.3))(typescript@5.8.3)
       find-up: 5.0.0
       magic-string: 0.30.17
@@ -2843,7 +2822,7 @@ snapshots:
       resolve: 1.22.10
       storybook: 8.6.14(prettier@3.5.3)
       tsconfig-paths: 4.2.0
-      vite: 6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)
     optionalDependencies:
       '@storybook/test': 8.6.14(storybook@8.6.14(prettier@3.5.3))
     transitivePeerDependencies:
@@ -3012,12 +2991,12 @@ snapshots:
       postcss: 8.5.3
       tailwindcss: 4.1.7
 
-  '@tailwindcss/vite@4.1.7(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))':
+  '@tailwindcss/vite@4.1.7(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1))':
     dependencies:
       '@tailwindcss/node': 4.1.7
       '@tailwindcss/oxide': 4.1.7
       tailwindcss: 4.1.7
-      vite: 6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)
 
   '@testing-library/dom@10.4.0':
     dependencies:
@@ -3077,11 +3056,11 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/react-dom@19.1.5(@types/react@19.1.5)':
+  '@types/react-dom@19.1.6(@types/react@19.1.6)':
     dependencies:
-      '@types/react': 19.1.5
+      '@types/react': 19.1.6
 
-  '@types/react@19.1.5':
+  '@types/react@19.1.6':
     dependencies:
       csstype: 3.1.3
 
@@ -3089,11 +3068,11 @@ snapshots:
 
   '@types/uuid@9.0.8': {}
 
-  '@vitejs/plugin-react-swc@3.10.0(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))':
+  '@vitejs/plugin-react-swc@3.10.0(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.9
       '@swc/core': 1.11.29
-      vite: 6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -3719,13 +3698,12 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(yaml@2.8.0):
+  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.4.2
       postcss: 8.5.3
-      yaml: 2.8.0
 
   postcss-value-parser@4.2.0: {}
 
@@ -3990,7 +3968,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.0(@swc/core@1.11.29)(jiti@2.4.2)(postcss@8.5.3)(typescript@5.8.3)(yaml@2.8.0):
+  tsup@8.5.0(@swc/core@1.11.29)(jiti@2.4.2)(postcss@8.5.3)(typescript@5.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.4)
       cac: 6.7.14
@@ -4001,7 +3979,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.3)(yaml@2.8.0)
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.3)
       resolve-from: 5.0.0
       rollup: 4.41.1
       source-map: 0.8.0-beta.0
@@ -4077,7 +4055,7 @@ snapshots:
 
   uuid@9.0.1: {}
 
-  vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0):
+  vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1):
     dependencies:
       esbuild: 0.25.4
       fdir: 6.4.4(picomatch@4.0.2)
@@ -4090,7 +4068,6 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.30.1
-      yaml: 2.8.0
 
   webidl-conversions@4.0.2: {}
 
@@ -4133,8 +4110,5 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@5.0.0: {}
-
-  yaml@2.8.0:
-    optional: true
 
   yocto-queue@0.1.0: {}

--- a/scripts/release.bash
+++ b/scripts/release.bash
@@ -1,0 +1,175 @@
+#!/bin/bash
+
+# Script: release.bash
+# Description: Automated version management and publishing for packages in @halvaradop/ui
+# Usage: ./release.bash [--publish] [--dry-run]
+# By default, only updates versions without publishing. The --publish and --dry-run options control publishing behavior.
+# --publish will publish the packages, and --dry-run simulates publishing without making changes.
+
+set -eo pipefail
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+PACKAGES_DIR="${ROOT_DIR}/packages"
+TODAY=$(date +'%Y-%m-%d')
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+PUBLISH=false
+DRY_RUN=false
+
+validate_environment() {
+  if [ ! -d "${PACKAGES_DIR}" ]; then
+    echo -e "${RED}Error: 'packages' directory not found.${NC}"
+    exit 1
+  fi
+  if ! command -v jq &> /dev/null; then
+    echo -e "${RED}Error: 'jq' is not installed.${NC}"
+    exit 1
+  fi
+  if [[ -n $(git status --porcelain) ]]; then
+    echo -e "${RED}Error: There are uncommitted changes.${NC}"
+    git status --short
+    exit 1
+  fi
+}
+
+get_package_name() {
+  local pkg_dir="$1"
+  jq -r '.name' "${pkg_dir}/package.json"
+}
+
+get_package_version() {
+  local pkg_dir="$1"
+  jq -r '.version' "${pkg_dir}/package.json"
+}
+
+get_package_display_name() {
+  local pkg_dir="$1"
+  local full_name
+  full_name=$(get_package_name "$pkg_dir")
+  echo "${full_name#@halvaradop/}"
+}
+
+increment_version() {
+  local version="$1"
+  local component="$2"
+  IFS='.' read -r major minor patch <<< "$version"
+  case "$component" in
+    major) echo "$((major + 1)).0.0" ;;
+    minor) echo "${major}.$((minor + 1)).0" ;;
+    patch) echo "${major}.${minor}.$((patch + 1))" ;;
+    *) echo -e "${RED}Error: Invalid version type${NC}"; exit 1 ;;
+  esac
+}
+
+update_package_version() {
+  local pkg_dir="$1"
+  local new_version="$2"
+  local pkg_name
+  pkg_name=$(get_package_name "$pkg_dir")
+
+  echo -e "${GREEN}Updating ${pkg_name} to version ${new_version}${NC}"
+  jq --arg v "$new_version" '.version = $v' "${pkg_dir}/package.json" > "${pkg_dir}/temp.json"
+  mv "${pkg_dir}/temp.json" "${pkg_dir}/package.json"
+
+  find "$PACKAGES_DIR" -name "package.json" -exec sed -i.bak "s#\"${pkg_name}\": \"[^\"]*\"#\"${pkg_name}\": \"^${new_version}\"#g" {} \;
+  find "$PACKAGES_DIR" -name "*.bak" -delete
+
+  if [ -f "${pkg_dir}/CHANGELOG.md" ]; then
+    sed -i.bak "s|## \\[Unreleased\\]|## [Unreleased]\n\n## [${new_version}] - ${TODAY}|" "${pkg_dir}/CHANGELOG.md"
+    rm -f "${pkg_dir}/CHANGELOG.md.bak"
+  fi
+}
+
+publish_package() {
+  local pkg_dir="$1"
+  local pkg_name="$2"
+  cd "$pkg_dir"
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "${YELLOW}[DRY RUN] Would publish ${pkg_name} from ${pkg_dir}${NC}"
+  else
+    echo -e "${GREEN}Publishing ${pkg_name} from ${pkg_dir}${NC}"
+    pnpm publish --access public --no-git-checks
+  fi
+  cd "$ROOT_DIR"
+}
+
+process_package() {
+  local pkg_folder="$1"
+  local pkg_dir="${PACKAGES_DIR}/${pkg_folder}"
+  if [ ! -f "${pkg_dir}/package.json" ]; then
+    echo -e "${RED}Error: package.json not found in ${pkg_dir}${NC}"
+    return
+  fi
+
+  local pkg_name
+  pkg_name=$(get_package_name "$pkg_dir")
+  local current_version
+  current_version=$(get_package_version "$pkg_dir")
+
+  echo -e "\n${YELLOW}Processing: ${pkg_name} (${pkg_folder})${NC}"
+  echo "Current version: ${current_version}"
+
+  PS3="Select the update type: "
+  options=("Major (x.0.0)" "Minor (x.y.0)" "Patch (x.y.z)" "Skip this package" "Cancel all")
+  select opt in "${options[@]}"; do
+    case $opt in
+      "Major (x.0.0)") new_version=$(increment_version "$current_version" "major"); break ;;
+      "Minor (x.y.0)") new_version=$(increment_version "$current_version" "minor"); break ;;
+      "Patch (x.y.z)") new_version=$(increment_version "$current_version" "patch"); break ;;
+      "Skip this package") return ;;
+      "Cancel all") exit 0 ;;
+      *) echo -e "${RED}Invalid option${NC}" ;;
+    esac
+  done
+
+  update_package_version "$pkg_dir" "$new_version"
+  if [ "$PUBLISH" = true ]; then
+    publish_package "$pkg_dir" "$pkg_name"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --publish) PUBLISH=true; shift ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    *) echo -e "${RED}Unrecognized argument: $1${NC}"; exit 1 ;;
+  esac
+done
+
+main() {
+  validate_environment
+  echo -e "${GREEN}=== Version Manager for @halvaradop/ui ===${NC}\n"
+  echo -e "${YELLOW}Detected packages:${NC}"
+
+  for pkg_dir in "${PACKAGES_DIR}"/*; do
+    if [ -f "${pkg_dir}/package.json" ]; then
+      pkg_name=$(get_package_name "$pkg_dir")
+      current_version=$(get_package_version "$pkg_dir")
+      echo " - ${pkg_name} (v${current_version})"
+    fi
+  done
+
+  for pkg_dir in "${PACKAGES_DIR}"/*; do
+    if [ -d "$pkg_dir" ]; then
+      pkg_folder=$(basename "$pkg_dir")
+      process_package "$pkg_folder"
+    fi
+  done
+
+  if [[ -n $(git status --porcelain) ]]; then
+    git add -A
+    git commit -m "chore(release): update package versions [skip ci]"
+    echo -e "\n${GREEN}Changes committed.${NC}"
+  else
+    echo -e "\n${YELLOW}No changes to commit.${NC}"
+  fi
+
+  echo -e "\n${GREEN}Process completed.${NC}"
+}
+
+main
+

--- a/scripts/release.bash
+++ b/scripts/release.bash
@@ -19,6 +19,8 @@ NC='\033[0m'
 
 PUBLISH=false
 DRY_RUN=false
+PUBLISH_CURRENT=false
+PREPUBLISH_TAG=""
 
 validate_environment() {
   if [ ! -d "${PACKAGES_DIR}" ]; then
@@ -87,12 +89,32 @@ update_package_version() {
 publish_package() {
   local pkg_dir="$1"
   local pkg_name="$2"
+  local publish_version="$3"
+  local publish_tag="$4"
   cd "$pkg_dir"
   if [ "$DRY_RUN" = true ]; then
-    echo -e "${YELLOW}[DRY RUN] Would publish ${pkg_name} from ${pkg_dir}${NC}"
+    echo -e "${YELLOW}[DRY RUN] Would publish ${pkg_name} from ${pkg_dir} (version: ${publish_version}, tag: ${publish_tag})${NC}"
   else
-    echo -e "${GREEN}Publishing ${pkg_name} from ${pkg_dir}${NC}"
-    pnpm publish --access public --no-git-checks
+    echo -e "${GREEN}Publishing ${pkg_name} from ${pkg_dir} (version: ${publish_version}, tag: ${publish_tag})${NC}"
+    if [ -n "$publish_tag" ]; then
+      pnpm publish --access public --no-git-checks --tag "$publish_tag"
+    else
+      pnpm publish --access public --no-git-checks
+    fi
+  fi
+  cd "$ROOT_DIR"
+}
+
+publish_package_with_tag() {
+  local pkg_dir="$1"
+  local pkg_name="$2"
+  local tag="$3"
+  cd "$pkg_dir"
+  if [ "$DRY_RUN" = true ]; then
+    echo -e "${YELLOW}[DRY RUN] Would publish ${pkg_name} with tag ${tag} from ${pkg_dir}${NC}"
+  else
+    echo -e "${GREEN}Publishing ${pkg_name} with tag ${tag} from ${pkg_dir}${NC}"
+    pnpm publish --access public --no-git-checks --tag "$tag"
   fi
   cd "$ROOT_DIR"
 }
@@ -113,6 +135,32 @@ process_package() {
   echo -e "\n${YELLOW}Processing: ${pkg_name} (${pkg_folder})${NC}"
   echo "Current version: ${current_version}"
 
+  if [ "$PUBLISH_CURRENT" = true ]; then
+    if [ "$PUBLISH" = true ]; then
+      publish_package "$pkg_dir" "$pkg_name" "$current_version" ""
+    fi
+    return
+  fi
+
+  if [ -n "$PREPUBLISH_TAG" ]; then
+    # Detect if current version already has a pre-release tag
+    if [[ "$current_version" =~ -$PREPUBLISH_TAG\.([0-9]+)$ ]]; then
+      # Extract the current pre-release number and increment it
+      pre_num=${BASH_REMATCH[1]}
+      base_version=${current_version%%-$PREPUBLISH_TAG.*}
+      next_pre_num=$((pre_num + 1))
+      pre_version="${base_version}-${PREPUBLISH_TAG}.${next_pre_num}"
+    else
+      pre_version="${current_version}-${PREPUBLISH_TAG}.0"
+    fi
+    echo -e "${GREEN}Preparing pre-release: ${pre_version} (tag: ${PREPUBLISH_TAG})${NC}"
+    update_package_version "$pkg_dir" "$pre_version"
+    if [ "$PUBLISH" = true ]; then
+      publish_package "$pkg_dir" "$pkg_name" "$pre_version" "$PREPUBLISH_TAG"
+    fi
+    return
+  fi
+
   PS3="Select the update type: "
   options=("Major (x.0.0)" "Minor (x.y.0)" "Patch (x.y.z)" "Skip this package" "Cancel all")
   select opt in "${options[@]}"; do
@@ -128,7 +176,7 @@ process_package() {
 
   update_package_version "$pkg_dir" "$new_version"
   if [ "$PUBLISH" = true ]; then
-    publish_package "$pkg_dir" "$pkg_name"
+    publish_package "$pkg_dir" "$pkg_name" "$new_version" ""
   fi
 }
 
@@ -136,12 +184,21 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --publish) PUBLISH=true; shift ;;
     --dry-run) DRY_RUN=true; shift ;;
+    --publish-current) PUBLISH=true; PUBLISH_CURRENT=true; shift ;;
+    --prepublish)
+      PUBLISH=true
+      PREPUBLISH_TAG="$2"
+      if [ -z "$PREPUBLISH_TAG" ]; then
+        echo -e "${RED}Error: --prepublish requires a tag (e.g., rc, beta, next)${NC}"
+        exit 1
+      fi
+      shift 2 ;;
     *) echo -e "${RED}Unrecognized argument: $1${NC}"; exit 1 ;;
   esac
 done
 
 main() {
-  validate_environment
+  # validate_environment
   echo -e "${GREEN}=== Version Manager for @halvaradop/ui ===${NC}\n"
   echo -e "${YELLOW}Detected packages:${NC}"
 
@@ -161,9 +218,13 @@ main() {
   done
 
   if [[ -n $(git status --porcelain) ]]; then
-    git add -A
-    git commit -m "chore(release): update package versions [skip ci]"
-    echo -e "\n${GREEN}Changes committed.${NC}"
+    if [ "$DRY_RUN" = true ]; then
+      echo -e "\n${YELLOW}[DRY RUN] No commit will be created.${NC}"
+    else
+      git add -A
+      git commit -m "chore(release): update package versions [skip ci]"
+      echo -e "\n${GREEN}Changes committed.${NC}"
+    fi
   else
     echo -e "\n${YELLOW}No changes to commit.${NC}"
   fi


### PR DESCRIPTION

## Description

This pull request adds the `release.bash` script for releasing packages in the monorepo. These changes were retrived from the pull request [#168](https://github.com/halvaradop/ui/pull/168) and [#169](https://github.com/halvaradop/ui/pull/169)


> [!Note]
> Only the aforementioned changes have been synchronized from the master branch to the beta branch. This pull request was created to minimize potential issues during synchronization.


<!--Provide a detailed description or reasoning for the changes made -->

## Checklist

- [ ] Added documentation.
- [ ] The changes do not generate any warnings.
- [ ] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
