### PR TITLE
chore(release): bump to `legacy` version for Reac 18

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -69,24 +69,53 @@ Key packages:
 
 ## Branching & Versioning Strategy
 
-| Branch | React Version | Tailwind Version | Status |
-| ------ | ------------- | ---------------- | ------ |
-| master | React 18      | Tailwind v3      | Stable |
-| beta   | React 19      | Tailwind v4      | Beta   |
+| Branch          | React Version | Tailwind Version | Status |
+| --------------- | ------------- | ---------------- | ------ |
+| master          | React 19      | Tailwind v4      | Stable |
+| legacy/react-18 | React 18      | Tailwind v4      | Legacy |
 
-- `master`: Current stable (React 18)
-- `beta`: Pre-release (React 19, Tailwind v4)
-- After the next major release, `main` will track React 19, and React 18 will move to `react-18` for legacy maintenance.
+- `master`: This is the **primary development branch** for the library. It is currently optimized for **React 19** and leverages **Tailwind CSS v4**. All new features, major improvements, and active development efforts are focused here.
+- `legacy/react-18`: This branch serves as a **legacy support line** for **React 18**. It will receive critical bug fixes and security updates but is not intended for new feature development.
+
+### Strategy for Branch Transition
+
+This diagram illustrates the process of transitioning the primary development line:
 
 ```mermaid
 sequenceDiagram
-    participant Master
-    participant Beta
-    Master->>Beta: Create sync branch
-    Beta->>Beta: Resolve React 19 conflicts
-    Beta->>Beta: Update dependencies
-    Beta->>Beta: Verify functionality
+  participant OldMaster as master (React 18)
+  participant Beta as beta (React 19 Development)
+  participant NewMaster as master (React 19)
+  participant LegacyBranch as legacy/react-18
+
+  OldMaster->>LegacyBranch: Renamed to legacy/react-18
+  Beta->>NewMaster: Renamed to master (now main development branch)
+
+  Note over NewMaster, LegacyBranch: After transition:
+  NewMaster->>NewMaster: Active development for React 19
+  LegacyBranch->>LegacyBranch: Support and critical fixes for React 18
 ```
+
+### Current Synchronization Strategy
+
+While `master` (React 19) is the primary branch, if critical fixes or foundational changes are applied to `legacy/react-18` that also benefit `master`, synchronization will occur.
+
+```mermaid
+sequenceDiagram
+  participant Master(React 19)
+  participant Legacy/react-18(React 18)
+
+  Legacy/react-18->>Master(React 19): If critical fixes occur, synchronize
+  Master(React 19)->>Master(React 19): Integrate synchronized changes
+```
+
+## Historical Commit Prefixes ([SYNC])
+
+During the parallel development phase—when the beta branch (now `master`) was being prepared for React 19 while the `master` branch (now `legacy/react-18`) remained active for React 18—we used a specific commit prefix:
+
+- [SYNC]: Commits prefixed with [SYNC] indicate changes that were synchronized from the `master` branch (React 18) into the beta branch (React 19). This ensured that critical bug fixes, security updates, or foundational changes from the stable React 18 line were consistently integrated into the upcoming React 19 version.
+
+Although the presence of these [SYNC] prefixes can add some noise to the commit history of the current `master` branch, we have chosen to preserve them rather than remove them. This decision was made to maintain the integrity of the repository tree and avoid breaking the commit history between the previous branches (`master` and beta). Removing these prefixes would have resulted in greater issues with traceability and understanding the complete repository history in the future.
 
 ## Internal Utilities
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,30 +10,48 @@ Per-package version history is maintained inside each package’s own `CHANGELOG
 
 ## [Unreleased]
 
+---
+
+## [legacy] - 2025-06-09
+
+> **Release: React 18 Support**
+>
+> Version **0.y.z** marks the official release of our component library with full **React 18** compatibility. This version is a **direct promotion of the latest pre-release (`0.y.z-rc.n`)** and has passed all stability and regression tests in real-world environments. It includes all changes, improvements, and fixes introduced during the `rc` phase.
+>
+> While this release contains substantial updates (such as the complete migration to Tailwind CSS v4 and accessibility enhancements) similar to those in the main (`latest`) version, its purpose is to provide a dedicated support line for projects that still rely on React 18. Active development has moved to the `master` branch, which targets React 19.
+>
+> **Recommended update for React 18 users!**
+>
+> We strongly recommend updating to this version if your project still depends on React 18 to benefit from the latest fixes and optimizations. You can install it using the `legacy` tag on npm:
+>
+> ```bash
+> npm install @halvaradop/ui@legacy
+> ```
+>
+> We encourage users to plan their migration to React 19 to take advantage of the latest features and optimizations available in the `master` branch.
+
+---
+
 ## [rc pre-release] - 2025-06-07
 
 - Pre-release (`rc`) versions published for all major monorepo packages [#170](https://github.com/halvaradop/ui/pull/170):
 
-  - @halvaradop/ui-button
-  - @halvaradop/ui-checkbox
-  - @halvaradop/ui-core
-  - @halvaradop/ui-dialog
-  - @halvaradop/ui-form
-  - @halvaradop/ui-input
-  - @halvaradop/ui-label
-  - @halvaradop/ui-radio-group
-  - @halvaradop/ui-radio
-  - @halvaradop/ui-select
-  - @halvaradop/ui-slot
-  - @halvaradop/ui-submit
-  - @halvaradop/ui-template
-  - @halvaradop/ui-utils
+  - `@halvaradop/ui-button`
+  - `@halvaradop/ui-checkbox`
+  - `@halvaradop/ui-core`
+  - `@halvaradop/ui-dialog`
+  - `@halvaradop/ui-form`
+  - `@halvaradop/ui-input`
+  - `@halvaradop/ui-label`
+  - `@halvaradop/ui-radio-group`
+  - `@halvaradop/ui-radio`
+  - `@halvaradop/ui-select`
+  - `@halvaradop/ui-slot`
+  - `@halvaradop/ui-submit`
+  - `@halvaradop/ui-template`
+  - `@halvaradop/ui-utils`
 
   Each package incremented its pre-release version (`rc.0`, `rc.1`, etc.) as appropriate. These versions are available on npm under the `rc` tag for testing and validation prior to the stable release.
-
----
-
----
 
 ## Added
 
@@ -72,15 +90,11 @@ Per-package version history is maintained inside each package’s own `CHANGELOG
   After being removed in React 19 migration, `forwardRef` was re-added to restore compatibility with React 18’s `useRef`.  
   → [PR #78](https://github.com/halvaradop/ui/pull/78)
 
----
-
 ## Deprecated
 
 - **`@halvaradop/ui-radio` package**  
   The Radio component was deprecated and merged into `@halvaradop/ui-radio-group` to avoid duplication and Tailwind scanning issues.  
   → [PR #153](https://github.com/halvaradop/ui/pull/153), [Issue #144](https://github.com/halvaradop/ui/issues/144)
-
----
 
 ## Removed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,10 +60,9 @@ pnpm clean            # Clean the project
 
 ## 🌿 Branching Strategy
 
-- `master`: Current stable branch (React 18, will become legacy)
-- `beta`: React 19 development branch (will become new `main`)
-
-Use `[SYNC]` prefix to indicate synchronization PRs between branches.
+- **`master`**: The main development branch. Represents the latest stable release (currently React 19).
+- **`legacy/react-18`**: Maintains support for React 18. Only accepts critical fixes, bug patches, and minimal changes required for legacy compatibility.
+- Use the `[SYNC]` prefix in pull request titles to clearly indicate synchronization PRs that merge changes between branches (e.g., from `master` to `legacy/react-18`).
 
 ---
 
@@ -144,17 +143,18 @@ chore: upgrade dependencies
 
 ## 🚀 Pull Request Process
 
-1. Use a descriptive title and body
-2. Reference any related issues or PRs
-3. Add screenshots for UI changes
-4. Ensure all tests and builds pass
-5. Label PRs appropriately:
-   - `breaking`
-   - `accessibility`
-   - `[SYNC]`
-6. Get approval from a code owner
+1. Use a descriptive title and body that follow
+2. Reference any related issues or PRs in the body.
+3. Add screenshots or GIFs for UI changes to facilitate review.
+4. Ensure all tests pass (`pnpm test`)
+5. Confirm all builds pass (`pnpm build`).
+6. Label PRs appropriately (e.g., `breaking`, `accessibility`).
+7. Get approval from a code owner.
 
 Only maintainers listed in the [CODEOWNERS](https://github.com/halvaradop/ui/blob/master/.github/CODEOWNERS) file can approve PRs related to their assigned areas.
+
+> Note on [SYNC] commits:
+> Historically, during the transition phase, some commits in the master branch (formerly beta) might be prefixed with [SYNC]. These indicate changes synchronized from the legacy/react-18 branch. As a contributor, you should not use this prefix for new commits; it was specific to a past internal synchronization workflow.
 
 ---
 
@@ -184,10 +184,10 @@ Each package follows [Semantic Versioning](https://semver.org/) independently:
 
 Responsibilities:
 
-- Review and merge PRs only in assigned scope (see `CODEOWNERS`)
-- Maintain consistency across versions and branches
-- Ensure all packages follow naming and changelog conventions
-- Coordinate `[SYNC]` PRs between `master`, `beta`, and `react-18`
+- Reviewing and merging PRs only within their assigned scope (see `CODEOWNERS`).
+- Maintaining consistency across different versions and branches.
+- Ensuring all packages adhere to naming and changelog conventions.
+- Coordinating any necessary synchronizations between `master` and `legacy/react-18` (though the [SYNC] commit prefix is no longer in active use for new contributions, historical context remains).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ pnpm add @halvaradop/ui-button
 ### For React 19 (Beta)
 
 ```bash
-npm install @halvaradop/ui-button@beta
-yarn add @halvaradop/ui-button@beta
-pnpm add @halvaradop/ui-button@beta
+npm install @halvaradop/ui-button@legacy
+yarn add @halvaradop/ui-button@legacy
+pnpm add @halvaradop/ui-button@legacy
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @halvaradop/ui
+# @halvaradop/ui@legacy
 
 A modern, accessible, and customizable React UI component library, organized as a monorepo and styled with TailwindCSS v4. This library provides pre-styled, reusable components to help you build user interfaces faster and more consistently.
 
@@ -6,10 +6,15 @@ A modern, accessible, and customizable React UI component library, organized as 
 
 Supports both `React 18` and `React 19`. Use the table below to select the correct library version for your React version:
 
-| React version | Library version        |
-| ------------- | ---------------------- |
-| React 18      | Latest stable (^x.y.z) |
-| React 19      | Beta (^x.y.z-beta.n)   |
+| React version | Library version            | NPM tag  |
+| ------------- | -------------------------- | -------- |
+| React 19      | `^1.y.z` (latest stable)   | `latest` |
+| React 18      | `^0.y.z-legacy.n` (legacy) | `legacy` |
+
+> **Note:**
+>
+> - For React 19, install the default package version (`@halvaradop/ui-button`).
+> - For React 18, use the `@legacy` tag (`@halvaradop/ui-button@legacy`) to ensure compatibility.
 
 ## Installation
 
@@ -23,7 +28,7 @@ yarn add @halvaradop/ui-button
 pnpm add @halvaradop/ui-button
 ```
 
-### For React 19 (Beta)
+### For React 19 (Legacy)
 
 ```bash
 npm install @halvaradop/ui-button@legacy

--- a/packages/ui-button/CHANGELOG.md
+++ b/packages/ui-button/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.7.0] - 2025-06-09 (Version @legacy for React 18)
+
+> **Release: React 18 Support**
+>
+> Version **0.y.z** marks the official release of our component library with full **React 18** compatibility. This version is a **direct promotion of the latest pre-release (`0.y.z-rc.n`)** and has passed all stability and regression tests in real-world environments. It includes all changes, improvements, and fixes introduced during the `rc` phase.
+>
+> While this release contains substantial updates (such as the complete migration to Tailwind CSS v4 and accessibility enhancements) similar to those in the main (`latest`) version, its purpose is to provide a dedicated support line for projects that still rely on React 18. Active development has moved to the `master` branch, which targets React 19.
+>
+> **Recommended update for React 18 users!**
+>
+> We strongly recommend updating to this version if your project still depends on React 18 to benefit from the latest fixes and optimizations. You can install it using the `legacy` tag on npm:
+>
+> ```bash
+> npm install @halvaradop/ui@legacy
+> ```
+>
+> We encourage users to plan their migration to React 19 to take advantage of the latest features and optimizations available in the `master` branch.
+
+---
+
+## [0.6.0-rc.1] - 2025-06-07
+
 ### Changed
 
 - Migrated from Tailwind CSS v3 to v4. Removed deprecated CSS variables and added new auto-generated variables using the `@theme` directive. These changes improve consistency and reduce manual configuration. This change affected the Button component.  
@@ -14,14 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved accessibility (a11y) by adding WAI-ARIA attributes such as `role`, `type`, and `tabIndex` to the Button component.  
   [#165](https://github.com/halvaradop/ui/pull/165)
-
-### Notes
-
-- Tailwind CSS v4 changes impacted most components. The Button component now uses native variants instead of custom `addVariant()` definitions.
-
----
-
-## [0.6.0-rc.1] - 2025-06-07
 
 ### Notes
 

--- a/packages/ui-button/README.md
+++ b/packages/ui-button/README.md
@@ -4,9 +4,9 @@
 
 ## Installation
 
-There are two versions available: one for React 18 (stable) and one for React 19 (beta).
+There are two versions available: one for React 19 (stable) and one for React 18 (legacy).
 
-### React 18 (Stable)
+### React 19 (Stable)
 
 ```bash
 npm install @halvaradop/ui-button
@@ -14,12 +14,12 @@ yarn add @halvaradop/ui-button
 pnpm add @halvaradop/ui-button
 ```
 
-### React 19 (Beta)
+### React 18 (Legacy)
 
 ```bash
-npm install @halvaradop/ui-button@beta
-yarn add @halvaradop/ui-button@beta
-pnpm add @halvaradop/ui-button@beta
+npm install @halvaradop/ui-button@legacy
+yarn add @halvaradop/ui-button@legacy
+pnpm add @halvaradop/ui-button@legacy
 ```
 
 ## Usage

--- a/packages/ui-button/package.json
+++ b/packages/ui-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-button",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A customizable button component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",
   "scripts": {
@@ -20,6 +20,7 @@
     "url": "git+https://github.com/halvaradop/ui.git"
   },
   "publishConfig": {
+    "tag": "legacy",
     "access": "public",
     "registry": "https://registry.npmjs.org/@halvaradop/ui-button"
   },

--- a/packages/ui-checkbox/CHANGELOG.md
+++ b/packages/ui-checkbox/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.5.0] - 2025-06-09 - (Version @legacy for React 18)
+
+> **Release: React 18 Support**
+>
+> Version **0.y.z** marks the official release of our component library with full **React 18** compatibility. This version is a **direct promotion of the latest pre-release (`0.y.z-rc.n`)** and has passed all stability and regression tests in real-world environments. It includes all changes, improvements, and fixes introduced during the `rc` phase.
+>
+> While this release contains substantial updates (such as the complete migration to Tailwind CSS v4 and accessibility enhancements) similar to those in the main (`latest`) version, its purpose is to provide a dedicated support line for projects that still rely on React 18. Active development has moved to the `master` branch, which targets React 19.
+>
+> **Recommended update for React 18 users!**
+>
+> We strongly recommend updating to this version if your project still depends on React 18 to benefit from the latest fixes and optimizations. You can install it using the `legacy` tag on npm:
+>
+> ```bash
+> npm install @halvaradop/ui@legacy
+> ```
+>
+> We encourage users to plan their migration to React 19 to take advantage of the latest features and optimizations available in the `master` branch.
+
+---
+
+## [0.4.0-rc.1] - 2025-06-07
+
 ### Changed
 
 - Migrated from Tailwind CSS v3 to v4. Deprecated older CSS variables and introduced new ones using the `@theme` directive. This affects the configuration and structure of the Checkbox component.  
@@ -19,14 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed the `blue` and `yellow` variants from the `color` prop, which were inconsistent with the new CSS variable structure in Tailwind CSS v4.  
   [#152](https://github.com/halvaradop/ui/pull/152)
-
-### Notes
-
-- The migration to Tailwind CSS v4 affects all components that relied on older variant definitions or hardcoded variable names.
-
----
-
-## [0.4.0-rc.1] - 2025-06-07
 
 ### Notes
 

--- a/packages/ui-checkbox/README.md
+++ b/packages/ui-checkbox/README.md
@@ -4,9 +4,9 @@
 
 ## Installation
 
-There are two versions available: one for React 18 (stable) and one for React 19 (beta).
+There are two versions available: one for React 19 (stable) and one for React 18 (legacy).
 
-### React 18 (Stable)
+### React 19 (Stable)
 
 ```bash
 npm install @halvaradop/ui-checkbox
@@ -14,12 +14,12 @@ yarn add @halvaradop/ui-checkbox
 pnpm add @halvaradop/ui-checkbox
 ```
 
-### React 19 (Beta)
+### React 18 (Legacy)
 
 ```bash
-npm install @halvaradop/ui-checkbox@beta
-yarn add @halvaradop/ui-checkbox@beta
-pnpm add @halvaradop/ui-checkbox@beta
+npm install @halvaradop/ui-checkbox@legacy
+yarn add @halvaradop/ui-checkbox@legacy
+pnpm add @halvaradop/ui-checkbox@legacy
 ```
 
 ## Usage

--- a/packages/ui-checkbox/package.json
+++ b/packages/ui-checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-checkbox",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": false,
   "description": "A customizable Checkbox component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",
@@ -21,6 +21,7 @@
     "url": "git+https://github.com/halvaradop/ui.git"
   },
   "publishConfig": {
+    "tag": "legacy",
     "access": "public",
     "registry": "https://registry.npmjs.org/@halvaradop/ui-checkbox"
   },

--- a/packages/ui-core/CHANGELOG.md
+++ b/packages/ui-core/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.6.0] - 2025-06-09 - (Version @legacy for React 18)
+
+> **Release: React 18 Support**
+>
+> Version **0.y.z** marks the official release of our component library with full **React 18** compatibility. This version is a **direct promotion of the latest pre-release (`0.y.z-rc.n`)** and has passed all stability and regression tests in real-world environments. It includes all changes, improvements, and fixes introduced during the `rc` phase.
+>
+> While this release contains substantial updates (such as the complete migration to Tailwind CSS v4 and accessibility enhancements) similar to those in the main (`latest`) version, its purpose is to provide a dedicated support line for projects that still rely on React 18. Active development has moved to the `master` branch, which targets React 19.
+>
+> **Recommended update for React 18 users!**
+>
+> We strongly recommend updating to this version if your project still depends on React 18 to benefit from the latest fixes and optimizations. You can install it using the `legacy` tag on npm:
+>
+> ```bash
+> npm install @halvaradop/ui@legacy
+> ```
+>
+> We encourage users to plan their migration to React 19 to take advantage of the latest features and optimizations available in the `master` branch.
+
+---
+
+## [0.5.0-rc.1] - 2025-06-07
+
 ### Removed
 
 - Removed `slot.ts` and migrated its contents to the new `@halvaradop/ui-slot` package. This reduces bundle size for packages that do not use the Slot component.  
@@ -15,13 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `tsup.config.base.ts` and moved its contents to a new `@halvaradop/ui-utils` package for better organization of build and configuration utilities.  
   [#107](https://github.com/halvaradop/ui/pull/107)
 
-### Notes
-
 - The removal of `slot.ts` impacts packages relying on `SlotProps`. Ensure they import from `@halvaradop/ui-slot` moving forward.
-
----
-
-## [0.5.0-rc.1] - 2025-06-07
 
 ### Notes
 

--- a/packages/ui-core/README.md
+++ b/packages/ui-core/README.md
@@ -4,9 +4,9 @@
 
 ## Installation
 
-There are two versions available: one for React 18 (stable) and one for React 19 (beta).
+There are two versions available: one for React 19 (stable) and one for React 18 (legacy).
 
-### React 18 (Stable)
+### React 19 (Stable)
 
 ```bash
 npm install @halvaradop/ui-core
@@ -14,12 +14,12 @@ yarn add @halvaradop/ui-core
 pnpm add @halvaradop/ui-core
 ```
 
-### React 19 (Beta)
+### React 18 (Legacy)
 
 ```bash
-npm install @halvaradop/ui-core@beta
-yarn add @halvaradop/ui-core@beta
-pnpm add @halvaradop/ui-core@beta
+npm install @halvaradop/ui-core@legacy
+yarn add @halvaradop/ui-core@legacy
+pnpm add @halvaradop/ui-core@legacy
 ```
 
 ## Usage

--- a/packages/ui-core/package.json
+++ b/packages/ui-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-core",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "The core of the @halvaradop/ui library, providing customizable components with Tailwind CSS styling.",
   "type": "module",
   "scripts": {
@@ -20,6 +20,7 @@
     "url": "git+https://github.com/halvaradop/ui.git"
   },
   "publishConfig": {
+    "tag": "legacy",
     "access": "public",
     "registry": "https://registry.npmjs.org/@halvaradop/ui-core"
   },

--- a/packages/ui-dialog/CHANGELOG.md
+++ b/packages/ui-dialog/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.6.0] - 2025-06-09 (Version @legacy for React 18)
+
+> **Release: React 18 Support**
+>
+> Version **0.y.z** marks the official release of our component library with full **React 18** compatibility. This version is a **direct promotion of the latest pre-release (`0.y.z-rc.n`)** and has passed all stability and regression tests in real-world environments. It includes all changes, improvements, and fixes introduced during the `rc` phase.
+>
+> While this release contains substantial updates (such as the complete migration to Tailwind CSS v4 and accessibility enhancements) similar to those in the main (`latest`) version, its purpose is to provide a dedicated support line for projects that still rely on React 18. Active development has moved to the `master` branch, which targets React 19.
+>
+> **Recommended update for React 18 users!**
+>
+> We strongly recommend updating to this version if your project still depends on React 18 to benefit from the latest fixes and optimizations. You can install it using the `legacy` tag on npm:
+>
+> ```bash
+> npm install @halvaradop/ui@legacy
+> ```
+>
+> We encourage users to plan their migration to React 19 to take advantage of the latest features and optimizations available in the `master` branch.
+
+---
+
+## [0.5.0-rc.1] - 2025-06-07
+
 ### Changed
 
 - Migrated from Tailwind CSS v3 to v4. Deprecated legacy CSS variables and introduced new auto-generated ones using the `@theme` directive. These changes improve consistency and reduce configuration overhead for the Dialog component.  
@@ -14,14 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved accessibility (a11y) by adding WAI-ARIA attributes like `role`, `aria-modal`, and `tabIndex` to the Dialog component.  
   [#165](https://github.com/halvaradop/ui/pull/165)
-
-### Notes
-
-- Tailwind v4 changes affect how theming and variants are handled. Ensure that variable prefixes and accessibility props are aligned with the updated implementation.
-
----
-
-## [0.5.0-rc.1] - 2025-06-07
 
 ### Notes
 

--- a/packages/ui-dialog/README.md
+++ b/packages/ui-dialog/README.md
@@ -4,9 +4,9 @@
 
 ## Installation
 
-There are two versions available: one for React 18 (stable) and one for React 19 (beta).
+There are two versions available: one for React 19 (stable) and one for React 18 (legacy).
 
-### React 18 (Stable)
+### React 19 (Stable)
 
 ```bash
 npm install @halvaradop/ui-dialog
@@ -14,12 +14,12 @@ yarn add @halvaradop/ui-dialog
 pnpm add @halvaradop/ui-dialog
 ```
 
-### React 19 (Beta)
+### React 18 (Legacy)
 
 ```bash
-npm install @halvaradop/ui-dialog@beta
-yarn add @halvaradop/ui-dialog@beta
-pnpm add @halvaradop/ui-dialog@beta
+npm install @halvaradop/ui-dialog@legacy
+yarn add @halvaradop/ui-dialog@legacy
+pnpm add @halvaradop/ui-dialog@legacy
 ```
 
 ## Usage

--- a/packages/ui-dialog/package.json
+++ b/packages/ui-dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-dialog",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": false,
   "description": "A customizable Dialog component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",
@@ -21,6 +21,7 @@
     "url": "git+https://github.com/halvaradop/ui.git"
   },
   "publishConfig": {
+    "tag": "legacy",
     "access": "public",
     "registry": "https://registry.npmjs.org/@halvaradop/ui-dialog"
   },

--- a/packages/ui-form/CHANGELOG.md
+++ b/packages/ui-form/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.5.0] - 2025-06-09 (Version @legacy for React 18)
+
+> **Release: React 18 Support**
+>
+> Version **0.y.z** marks the official release of our component library with full **React 18** compatibility. This version is a **direct promotion of the latest pre-release (`0.y.z-rc.n`)** and has passed all stability and regression tests in real-world environments. It includes all changes, improvements, and fixes introduced during the `rc` phase.
+>
+> While this release contains substantial updates (such as the complete migration to Tailwind CSS v4 and accessibility enhancements) similar to those in the main (`latest`) version, its purpose is to provide a dedicated support line for projects that still rely on React 18. Active development has moved to the `master` branch, which targets React 19.
+>
+> **Recommended update for React 18 users!**
+>
+> We strongly recommend updating to this version if your project still depends on React 18 to benefit from the latest fixes and optimizations. You can install it using the `legacy` tag on npm:
+>
+> ```bash
+> npm install @halvaradop/ui@legacy
+> ```
+>
+> We encourage users to plan their migration to React 19 to take advantage of the latest features and optimizations available in the `master` branch.
+
+---
+
+## [0.4.0-rc.1] - 2025-06-07
+
 ### Changed
 
 - Migrated from Tailwind CSS v3 to v4. Replaced deprecated variables and introduced auto-generated ones via the `@theme` directive. The configuration is now handled natively without `tailwind.config.ts`. This affected the Form component.  
@@ -14,14 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved accessibility (a11y) by adding the `role` attribute to the Form component to enhance WAI-ARIA compliance.  
   [#165](https://github.com/halvaradop/ui/pull/165)
-
-### Notes
-
-- These changes reduce configuration overhead and increase clarity for consumers using Tailwind v4.
-
----
-
-## [0.4.0-rc.1] - 2025-06-07
 
 ### Notes
 

--- a/packages/ui-form/README.md
+++ b/packages/ui-form/README.md
@@ -4,9 +4,9 @@
 
 ## Installation
 
-There are two versions available: one for React 18 (stable) and one for React 19 (beta).
+There are two versions available: one for React 19 (stable) and one for React 18 (legacy).
 
-### React 18 (Stable)
+### React 19 (Stable)
 
 ```bash
 npm install @halvaradop/ui-form
@@ -14,12 +14,12 @@ yarn add @halvaradop/ui-form
 pnpm add @halvaradop/ui-form
 ```
 
-### React 19 (Beta)
+### React 18 (Legacy)
 
 ```bash
-npm install @halvaradop/ui-form@beta
-yarn add @halvaradop/ui-form@beta
-pnpm add @halvaradop/ui-form@beta
+npm install @halvaradop/ui-form@legacy
+yarn add @halvaradop/ui-form@legacy
+pnpm add @halvaradop/ui-form@legacy
 ```
 
 ## Usage

--- a/packages/ui-form/package.json
+++ b/packages/ui-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-form",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": false,
   "description": "A customizable form component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",
@@ -21,6 +21,7 @@
     "url": "git+https://github.com/halvaradop/ui.git"
   },
   "publishConfig": {
+    "tag": "legacy",
     "access": "public",
     "registry": "https://registry.npmjs.org/@halvaradop/ui-form"
   },

--- a/packages/ui-input/CHANGElOG.md
+++ b/packages/ui-input/CHANGElOG.md
@@ -7,6 +7,30 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.6.0] - 2025-06-09 (Version @legacy for React 18)
+
+> **Release: React 18 Support**
+>
+> Version **0.y.z** marks the official release of our component library with full **React 18** compatibility. This version is a **direct promotion of the latest pre-release (`0.y.z-rc.n`)** and has passed all stability and regression tests in real-world environments. It includes all changes, improvements, and fixes introduced during the `rc` phase.
+>
+> While this release contains substantial updates (such as the complete migration to Tailwind CSS v4 and accessibility enhancements) similar to those in the main (`latest`) version, its purpose is to provide a dedicated support line for projects that still rely on React 18. Active development has moved to the `master` branch, which targets React 19.
+>
+> **Recommended update for React 18 users!**
+>
+> We strongly recommend updating to this version if your project still depends on React 18 to benefit from the latest fixes and optimizations. You can install it using the `legacy` tag on npm:
+>
+> ```bash
+> npm install @halvaradop/ui@legacy
+> ```
+>
+> We encourage users to plan their migration to React 19 to take advantage of the latest features and optimizations available in the `master` branch.
+
+---
+
+## [0.5.0-rc.1] - 2025-06-07
+
 ### Changed
 
 - Migrated from Tailwind CSS v3 to v4. Deprecated legacy CSS variables and introduced new auto-generated ones via the `@theme` directive. This simplifies the configuration of the Input component and improves theme consistency.  
@@ -14,14 +38,6 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Improved accessibility by adding WAI-ARIA attributes such as `role` and `type` to the Input component.  
   [#165](https://github.com/halvaradop/ui/pull/165)
-
-### Notes
-
-- The Tailwind v4 migration eliminates the need for custom variants and external theme configuration via `tailwind.config.ts`.
-
----
-
-## [0.5.0-rc.1] - 2025-06-07
 
 ### Notes
 

--- a/packages/ui-input/README.md
+++ b/packages/ui-input/README.md
@@ -4,9 +4,9 @@
 
 ## Installation
 
-There are two versions available: one for React 18 (stable) and one for React 19 (beta).
+There are two versions available: one for React 19 (stable) and one for React 18 (legacy).
 
-### React 18 (Stable)
+### React 19 (Stable)
 
 Install the stable version:
 
@@ -16,12 +16,12 @@ yarn add @halvaradop/ui-input
 pnpm add @halvaradop/ui-input
 ```
 
-### React 19 (Beta)
+### React 18 (Legacy)
 
 ```bash
-npm install @halvaradop/ui-input@beta
-yarn add @halvaradop/ui-input@beta
-pnpm add @halvaradop/ui-input@beta
+npm install @halvaradop/ui-input@legacy
+yarn add @halvaradop/ui-input@legacy
+pnpm add @halvaradop/ui-input@legacy
 ```
 
 ## Usage

--- a/packages/ui-input/package.json
+++ b/packages/ui-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-input",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": false,
   "description": "A customizable input component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",
@@ -21,6 +21,7 @@
     "url": "git+https://github.com/halvaradop/ui.git"
   },
   "publishConfig": {
+    "tag": "legacy",
     "access": "public",
     "registry": "https://registry.npmjs.org/@halvaradop/ui-input"
   },

--- a/packages/ui-label/CHANGELOG.md
+++ b/packages/ui-label/CHANGELOG.md
@@ -7,6 +7,30 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.5.0] - 2025-06-09 (Version @legacy for React 18)
+
+> **Release: React 18 Support**
+>
+> Version **0.y.z** marks the official release of our component library with full **React 18** compatibility. This version is a **direct promotion of the latest pre-release (`0.y.z-rc.n`)** and has passed all stability and regression tests in real-world environments. It includes all changes, improvements, and fixes introduced during the `rc` phase.
+>
+> While this release contains substantial updates (such as the complete migration to Tailwind CSS v4 and accessibility enhancements) similar to those in the main (`latest`) version, its purpose is to provide a dedicated support line for projects that still rely on React 18. Active development has moved to the `master` branch, which targets React 19.
+>
+> **Recommended update for React 18 users!**
+>
+> We strongly recommend updating to this version if your project still depends on React 18 to benefit from the latest fixes and optimizations. You can install it using the `legacy` tag on npm:
+>
+> ```bash
+> npm install @halvaradop/ui@legacy
+> ```
+>
+> We encourage users to plan their migration to React 19 to take advantage of the latest features and optimizations available in the `master` branch.
+
+---
+
+## [0.4.0-rc.1] - 2025-06-07
+
 ### Changed
 
 - Migrated from Tailwind CSS v3 to v4. Updated internal CSS variable system to use native support from Tailwind v4 and the `@theme` directive. Old variables were removed and new ones were added. This affected the Label component’s styling and structure.  
@@ -22,13 +46,6 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - The migration to Tailwind CSS v4 removes the need for defining variants in `tailwind.config.ts`, allowing simpler native theming.
 - Ensure all usages of `Slot` are updated to use `@halvaradop/ui-slot`.
-
----
-
-## [0.4.0-rc.1] - 2025-06-07
-
-### Notes
-
 - This is a **release candidate** published under the `rc` tag to validate changes in preparation for the upcoming `1.0.0` major release.  
   See [#170](https://github.com/halvaradop/ui/pull/170)
 - Versioning and publishing were automated using the `release.bash` script.  

--- a/packages/ui-label/README.md
+++ b/packages/ui-label/README.md
@@ -4,9 +4,9 @@
 
 ## Installation
 
-There are two versions available: one for React 18 (stable) and one for React 19 (beta).
+There are two versions available: one for React 19 (stable) and one for React 18 (legacy).
 
-### React 18 (Stable)
+### React 19 (Stable)
 
 ```bash
 npm install @halvaradop/ui-label
@@ -14,12 +14,12 @@ yarn add @halvaradop/ui-label
 pnpm add @halvaradop/ui-label
 ```
 
-### React 19 (Beta)
+### React 18 (Legacy)
 
 ```bash
-npm install @halvaradop/ui-label@beta
-yarn add @halvaradop/ui-label@beta
-pnpm add @halvaradop/ui-label@beta
+npm install @halvaradop/ui-label@legacy
+yarn add @halvaradop/ui-label@legacy
+pnpm add @halvaradop/ui-label@legacy
 ```
 
 ## Usage

--- a/packages/ui-label/package.json
+++ b/packages/ui-label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-label",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": false,
   "description": "A customizable label component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",
@@ -21,6 +21,7 @@
     "url": "git+https://github.com/halvaradop/ui.git"
   },
   "publishConfig": {
+    "tag": "legacy",
     "access": "public",
     "registry": "https://registry.npmjs.org/@halvaradop/ui-label"
   },

--- a/packages/ui-radio-group/CHANGELOG.md
+++ b/packages/ui-radio-group/CHANGELOG.md
@@ -7,6 +7,30 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.4.0] - 2025-06-09 (Version @legacy for React 18)
+
+> **Release: React 18 Support**
+>
+> Version **0.y.z** marks the official release of our component library with full **React 18** compatibility. This version is a **direct promotion of the latest pre-release (`0.y.z-rc.n`)** and has passed all stability and regression tests in real-world environments. It includes all changes, improvements, and fixes introduced during the `rc` phase.
+>
+> While this release contains substantial updates (such as the complete migration to Tailwind CSS v4 and accessibility enhancements) similar to those in the main (`latest`) version, its purpose is to provide a dedicated support line for projects that still rely on React 18. Active development has moved to the `master` branch, which targets React 19.
+>
+> **Recommended update for React 18 users!**
+>
+> We strongly recommend updating to this version if your project still depends on React 18 to benefit from the latest fixes and optimizations. You can install it using the `legacy` tag on npm:
+>
+> ```bash
+> npm install @halvaradop/ui@legacy
+> ```
+>
+> We encourage users to plan their migration to React 19 to take advantage of the latest features and optimizations available in the `master` branch.
+
+---
+
+## [0.3.3-rc.1] - 2025-06-07
+
 ### Added
 
 - Migrated the `Radio` component from `@halvaradop/ui-radio` into this package. This unifies the logic using the Compound Component Pattern and avoids TailwindCSS scanning issues.  
@@ -19,13 +43,6 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Tailwind v4 compatibility is now fully native. Custom variants have been replaced by semantic tokens exposed via `@theme`.
 - This package now contains both `RadioGroup` and `Radio`, and consumers should migrate usage accordingly.
-
----
-
-## [0.3.3-rc.1] - 2025-06-07
-
-### Notes
-
 - This is a **release candidate** published under the `rc` tag to validate changes in preparation for the upcoming `1.0.0` major release.  
   See [#170](https://github.com/halvaradop/ui/pull/170)
 - Versioning and publishing were automated using the `release.bash` script.  

--- a/packages/ui-radio-group/README.md
+++ b/packages/ui-radio-group/README.md
@@ -4,9 +4,9 @@
 
 ## Installation
 
-There are two versions available: one for React 18 (stable) and one for React 19 (beta).
+There are two versions available: one for React 19 (stable) and one for React 18 (legacy).
 
-### React 18 (Stable)
+### React 19 (Stable)
 
 ```bash
 npm install @halvaradop/ui-radio-group
@@ -14,12 +14,12 @@ yarn add @halvaradop/ui-radio-group
 pnpm add @halvaradop/ui-radio-group
 ```
 
-### React 19 (Beta)
+### React 18 (Legacy)
 
 ```bash
-npm install @halvaradop/ui-radio-group@beta
-yarn add @halvaradop/ui-radio-group@beta
-pnpm add @halvaradop/ui-radio-group@beta
+npm install @halvaradop/ui-radio-group@legacy
+yarn add @halvaradop/ui-radio-group@legacy
+pnpm add @halvaradop/ui-radio-group@legacy
 ```
 
 ## Usage

--- a/packages/ui-radio-group/package.json
+++ b/packages/ui-radio-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-radio-group",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "private": false,
   "description": "A customizable Radio Group component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",
@@ -19,6 +19,11 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/halvaradop/ui.git"
+  },
+  "publishConfig": {
+    "tag": "legacy",
+    "access": "public",
+    "registry": "https://registry.npmjs.org/@halvaradop/ui-radio-group"
   },
   "keywords": [
     "react",

--- a/packages/ui-radio/CHANGELOG.md
+++ b/packages/ui-radio/CHANGELOG.md
@@ -7,25 +7,34 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Changed
+---
 
-- Updated CSS variables introduced in [#93](https://github.com/halvaradop/ui/pull/93) to address missing values and improve Tailwind v4 support.  
-  [#143](https://github.com/halvaradop/ui/pull/143)
+## [0.3.0] - 2025-06-09 (Version @legacy for React 18)
 
-### Fixed
+> **Release: React 18 Support**
+>
+> Version **0.y.z** marks the official release of our component library with full **React 18** compatibility. This version is a **direct promotion of the latest pre-release (`0.y.z-rc.n`)** and has passed all stability and regression tests in real-world environments. It includes all changes, improvements, and fixes introduced during the `rc` phase.
+>
+> While this release contains substantial updates (such as the complete migration to Tailwind CSS v4 and accessibility enhancements) similar to those in the main (`latest`) version, its purpose is to provide a dedicated support line for projects that still rely on React 18. Active development has moved to the `master` branch, which targets React 19.
+>
+> **Recommended update for React 18 users!**
+>
+> We strongly recommend updating to this version if your project still depends on React 18 to benefit from the latest fixes and optimizations. You can install it using the `legacy` tag on npm:
+>
+> ```bash
+> npm install @halvaradop/ui@legacy
+> ```
+>
+> We encourage users to plan their migration to React 19 to take advantage of the latest features and optimizations available in the `master` branch.
 
-- Fixed an issue triggered by the `useRef` hook in the `@halvaradop/ui-radio-group` package, which was indirectly affected by the `Radio` component.  
-  [#122](https://github.com/halvaradop/ui/pull/122)
+### Breaking Changes
 
-### Deprecated
-
-- **Deprecated**: This package is now deprecated and will no longer receive updates or bug fixes.  
-  The `Radio` component was moved into the `@halvaradop/ui-radio-group` package to avoid Tailwind CSS scanning issues.  
+- The `Radio` component has been removed from this package and is now available in the `@halvaradop/ui-radio-group` package to address Tailwind CSS scanning issues.  
   [#153](https://github.com/halvaradop/ui/pull/153), [#144](https://github.com/halvaradop/ui/issues/144)
 
-### Notes
+#### Migration
 
-- Consumers should migrate to `@halvaradop/ui-radio-group`, which now includes the logic and styles previously contained here.
+- Please migrate to `@halvaradop/ui-radio-group`, which now contains the logic and styles previously provided by this package.
 
 ---
 

--- a/packages/ui-radio/package.json
+++ b/packages/ui-radio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-radio",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": false,
   "description": "DEPRECATED: Use @halvaradop/ui-radio-group instead. This package will no longer receive updates.",
   "deprecated": true,
@@ -21,6 +21,11 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/halvaradop/ui.git"
+  },
+  "publishConfig": {
+    "tag": "legacy",
+    "access": "public",
+    "registry": "https://registry.npmjs.org/@halvaradop/ui-radio"
   },
   "keywords": [
     "react",

--- a/packages/ui-select/CHANGELOG.md
+++ b/packages/ui-select/CHANGELOG.md
@@ -7,6 +7,30 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.2.0] - 2025-06-09 (Version @legacy for React 18)
+
+> **Release: React 18 Support**
+>
+> Version **0.y.z** marks the official release of our component library with full **React 18** compatibility. This version is a **direct promotion of the latest pre-release (`0.y.z-rc.n`)** and has passed all stability and regression tests in real-world environments. It includes all changes, improvements, and fixes introduced during the `rc` phase.
+>
+> While this release contains substantial updates (such as the complete migration to Tailwind CSS v4 and accessibility enhancements) similar to those in the main (`latest`) version, its purpose is to provide a dedicated support line for projects that still rely on React 18. Active development has moved to the `master` branch, which targets React 19.
+>
+> **Recommended update for React 18 users!**
+>
+> We strongly recommend updating to this version if your project still depends on React 18 to benefit from the latest fixes and optimizations. You can install it using the `legacy` tag on npm:
+>
+> ```bash
+> npm install @halvaradop/ui@legacy
+> ```
+>
+> We encourage users to plan their migration to React 19 to take advantage of the latest features and optimizations available in the `master` branch.
+
+---
+
+## [0.1.0-rc.1] - 2025-06-07
+
 ### Changed
 
 - Updated CSS variables for Tailwind CSS v4 compatibility. Legacy variable naming was replaced by auto-generated tokens based on the `@theme` directive. This modernizes the Select component styling and configuration.  
@@ -16,31 +40,6 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Tailwind v4 eliminates the need to configure CSS variables in `tailwind.config.ts`. Variables are now generated automatically.
 - Native variants and theming simplify the use and styling of the Select component.
-
----
-
-## [0.1.0-rc.1] - 2025-06-07
-
-### Notes
-
-- This is a **release candidate** published under the `rc` tag to validate changes in preparation for the upcoming `1.0.0` major release.  
-  See [#170](https://github.com/halvaradop/ui/pull/170)
-- Versioning and publishing were automated using the `release.bash` script.  
-  See [#170](https://github.com/halvaradop/ui/pull/170)
-- The purpose of this release is to test the release workflow in real environments before finalizing the stable release.  
-  See [#170](https://github.com/halvaradop/ui/pull/170)
-
-> No breaking changes have been introduced in this release candidate.  
-> The final release will follow after successful validation.
-
-This release was initiated based on [#169](https://github.com/halvaradop/ui/issues/169), which outlines the reasoning for upgrading to a stable major version.
-
----
-
-## [0.1.0-rc.1] - 2025-06-07
-
-### Notes
-
 - This is a **release candidate** published under the `rc` tag to validate changes in preparation for the upcoming `1.0.0` major release.  
   See [#170](https://github.com/halvaradop/ui/pull/170)
 - Versioning and publishing were automated using the `release.bash` script.  

--- a/packages/ui-select/README.md
+++ b/packages/ui-select/README.md
@@ -4,9 +4,9 @@
 
 ## Installation
 
-There are two versions available: one for React 18 (stable) and one for React 19 (beta).
+There are two versions available: one for React 19 (stable) and one for React 18 (legacy).
 
-### React 18 (Stable)
+### React 19 (Stable)
 
 ```bash
 npm install @halvaradop/ui-select
@@ -14,12 +14,12 @@ yarn add @halvaradop/ui-select
 pnpm add @halvaradop/ui-select
 ```
 
-### React 19 (Beta)
+### React 18 (Legacy)
 
 ```bash
-npm install @halvaradop/ui-select@beta
-yarn add @halvaradop/ui-select@beta
-pnpm add @halvaradop/ui-select@beta
+npm install @halvaradop/ui-select@legacy
+yarn add @halvaradop/ui-select@legacy
+pnpm add @halvaradop/ui-select@legacy
 ```
 
 ## Usage

--- a/packages/ui-select/package.json
+++ b/packages/ui-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-select",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": false,
   "description": "A customizable Select component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",
@@ -19,6 +19,11 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/halvaradop/ui.git"
+  },
+  "publishConfig": {
+    "tag": "legacy",
+    "access": "public",
+    "registry": "https://registry.npmjs.org/@halvaradop/ui-select"
   },
   "keywords": [
     "react",

--- a/packages/ui-slot/CHANGELOG.md
+++ b/packages/ui-slot/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 This changelog follows the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format  
 and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2025-06-09 (Version @legacy for React 18)
+
+> **Release: React 18 Support**
+>
+> Version **0.y.z** marks the official release of our component library with full **React 18** compatibility. This version is a **direct promotion of the latest pre-release (`0.y.z-rc.n`)** and has passed all stability and regression tests in real-world environments. It includes all changes, improvements, and fixes introduced during the `rc` phase.
+>
+> While this release contains substantial updates (such as the complete migration to Tailwind CSS v4 and accessibility enhancements) similar to those in the main (`latest`) version, its purpose is to provide a dedicated support line for projects that still rely on React 18. Active development has moved to the `master` branch, which targets React 19.
+>
+> **Recommended update for React 18 users!**
+>
+> We strongly recommend updating to this version if your project still depends on React 18 to benefit from the latest fixes and optimizations. You can install it using the `legacy` tag on npm:
+>
+> ```bash
+> npm install @halvaradop/ui@legacy
+> ```
+>
+> We encourage users to plan their migration to React 19 to take advantage of the latest features and optimizations available in the `master` branch.
+
 ## [0.1.0-rc.1] - 2025-06-07
 
 ### Notes

--- a/packages/ui-slot/README.md
+++ b/packages/ui-slot/README.md
@@ -4,9 +4,9 @@
 
 ## Installation
 
-There are two versions available: one for React 18 (stable) and one for React 19 (beta).
+There are two versions available: one for React 19 (stable) and one for React 18 (legacy).
 
-### React 18 (Stable)
+### React 19 (Stable)
 
 ```bash
 npm install @halvaradop/ui-slot
@@ -14,12 +14,12 @@ yarn add @halvaradop/ui-slot
 pnpm add @halvaradop/ui-slot
 ```
 
-### React 19 (Beta)
+### React 18 (Legacy)
 
 ```bash
-npm install @halvaradop/ui-slot@beta
-yarn add @halvaradop/ui-slot@beta
-pnpm add @halvaradop/ui-slot@beta
+npm install @halvaradop/ui-slot@legacy
+yarn add @halvaradop/ui-slot@legacy
+pnpm add @halvaradop/ui-slot@legacy
 ```
 
 ## Usage

--- a/packages/ui-slot/package.json
+++ b/packages/ui-slot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-slot",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": false,
   "description": "A customizable Slot component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",
@@ -19,6 +19,11 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/halvaradop/ui.git"
+  },
+  "publishConfig": {
+    "tag": "legacy",
+    "access": "public",
+    "registry": "https://registry.npmjs.org/@halvaradop/ui-slot"
   },
   "keywords": [
     "react",

--- a/packages/ui-submit/CHANGELOG.md
+++ b/packages/ui-submit/CHANGELOG.md
@@ -7,6 +7,30 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.5.0] - 2025-06-09 (Version @legacy for React 18)
+
+> **Release: React 18 Support**
+>
+> Version **0.y.z** marks the official release of our component library with full **React 18** compatibility. This version is a **direct promotion of the latest pre-release (`0.y.z-rc.n`)** and has passed all stability and regression tests in real-world environments. It includes all changes, improvements, and fixes introduced during the `rc` phase.
+>
+> While this release contains substantial updates (such as the complete migration to Tailwind CSS v4 and accessibility enhancements) similar to those in the main (`latest`) version, its purpose is to provide a dedicated support line for projects that still rely on React 18. Active development has moved to the `master` branch, which targets React 19.
+>
+> **Recommended update for React 18 users!**
+>
+> We strongly recommend updating to this version if your project still depends on React 18 to benefit from the latest fixes and optimizations. You can install it using the `legacy` tag on npm:
+>
+> ```bash
+> npm install @halvaradop/ui@legacy
+> ```
+>
+> We encourage users to plan their migration to React 19 to take advantage of the latest features and optimizations available in the `master` branch.
+
+---
+
+## [0.4.0-rc.1] - 2025-06-07
+
 ### Changed
 
 - Migrated from Tailwind CSS v3 to v4. Replaced legacy custom variants with native support using the `@theme` directive. This simplifies the component's variant logic.  
@@ -18,13 +42,6 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Notes
 
 - All variant definitions and sizing logic were simplified thanks to Tailwind’s native support for state-based selectors like `:user-valid` and `:placeholder-shown`.
-
----
-
-## [0.4.0-rc.1] - 2025-06-07
-
-### Notes
-
 - This is a **release candidate** published under the `rc` tag to validate changes in preparation for the upcoming `1.0.0` major release.  
   See [#170](https://github.com/halvaradop/ui/pull/170)
 - Versioning and publishing were automated using the `release.bash` script.  

--- a/packages/ui-submit/README.md
+++ b/packages/ui-submit/README.md
@@ -4,9 +4,9 @@
 
 ## Installation
 
-There are two versions available: one for React 18 (stable) and one for React 19 (beta).
+There are two versions available: one for React 19 (stable) and one for React 18 (legacy).
 
-### React 18 (Stable)
+### React 19 (Stable)
 
 ```bash
 npm install @halvaradop/ui-submit
@@ -14,12 +14,12 @@ yarn add @halvaradop/ui-submit
 pnpm add @halvaradop/ui-submit
 ```
 
-### React 19 (Beta)
+### React 18 (Legacy)
 
 ```bash
-npm install @halvaradop/ui-submit@beta
-yarn add @halvaradop/ui-submit@beta
-pnpm add @halvaradop/ui-submit@beta
+npm install @halvaradop/ui-submit@legacy
+yarn add @halvaradop/ui-submit@legacy
+pnpm add @halvaradop/ui-submit@legacy
 ```
 
 ## Usage

--- a/packages/ui-submit/package.json
+++ b/packages/ui-submit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@halvaradop/ui-submit",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": false,
   "description": "A customizable submit component for @halvaradop/ui library with Tailwind CSS styling.",
   "type": "module",
@@ -21,6 +21,7 @@
     "url": "git+https://github.com/halvaradop/ui.git"
   },
   "publishConfig": {
+    "tag": "legacy",
     "access": "public",
     "registry": "https://registry.npmjs.org/@halvaradop/ui-submit"
   },

--- a/packages/ui-template/README.md
+++ b/packages/ui-template/README.md
@@ -7,9 +7,9 @@
 
 ## Installation
 
-There are two versions available: one for React 18 (stable) and one for React 19 (beta).
+There are two versions available: one for React 19 (stable) and one for React 18 (legacy).
 
-### React 18 (Stable)
+### React 19 (Stable)
 
 ```bash
 npm install @halvaradop/ui-template
@@ -17,12 +17,12 @@ yarn add @halvaradop/ui-template
 pnpm add @halvaradop/ui-template
 ```
 
-### React 19 (Beta)
+### React 18 (Legacy)
 
 ```bash
-npm install @halvaradop/ui-template@beta
-yarn add @halvaradop/ui-template@beta
-pnpm add @halvaradop/ui-template@beta
+npm install @halvaradop/ui-template@legacy
+yarn add @halvaradop/ui-template@legacy
+pnpm add @halvaradop/ui-template@legacy
 ```
 
 ## Usage


### PR DESCRIPTION
# Legacy Release: @halvaradop/ui @legacy for React 18

## Description

This pull request publishes **version 0.y.z** of the `@halvaradop/ui` component library, designated as the **support line for React 18**. This version is available on npm under the **`legacy` tag**.

This release consolidates the latest changes and significant improvements introduced in what was previously the main `master` branch (now `legacy/react-18`). It has undergone stability and regression testing. This marks the transition of this line to a state of **maintenance and support exclusively for critical bug and security fixes**, while active development and new features are focused on the `master` branch (React 19).

---

## 🎯 Key Highlights of the `0.y.z` Version (Legacy Line)

This version incorporates the last significant updates prior to the branch transition:

-   **🎨 Tailwind CSS v4 Migration**
    The transition to Tailwind CSS v4 is finalized, integrating its performance improvements, updated configuration, and new utilities.
    * **Note:** This change introduces a major update to the styling foundation that might require adjustments if your project also uses Tailwind CSS.

-   **♿ Accessibility (a11y) Improvements**
    Accessibility has been enhanced across several components, including the addition of proper WAI-ARIA attributes and other adjustments for a more inclusive and standards-compliant user experience.

---

## 📄 Documentation Updates

The following files have been updated to reflect the status of the `legacy/react-18` branch and the new branching strategy:

-   `CHANGELOG.md` (root): Details the `0.y.z` version's status as `legacy`.
-   `README.md` (root and package-level): Information on how to install the `legacy` version and its purpose.
-   `CONTRIBUTING.md`: Updated guidelines on how to contribute to the support branch.
-   `ARCHITECTURE.md`: Includes the new branching strategy and the history of the transition.

---

## 📦 Pre-Release History (React 18 Line)

Prior to this publication, `rc` (release candidate) pre-releases were used for testing and validation within the React 18 line:

-   `rc` (release candidates): Final validation versions that led to the stability of this line before its designation as `legacy`.

For more context on the general branching strategy, please refer to [issue #169](https://github.com/halvaradop/ui/issues/169) on the `master` branch.


<!--Provide a detailed description or reasoning for the changes made -->

## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
