### PR TITLE
fix(config): remove `"use client"` directive to fix ui-core build

### DIFF
--- a/packages/ui-core/tsup.config.ts
+++ b/packages/ui-core/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig((options) => {
         sourcemap: env !== "production",
         minify: env === "production",
         bundle: env === "production",
+        banner: {},
         ...options,
     }
 })


### PR DESCRIPTION
## Description

This pull request removes the `"use client"` directive from the `@halvaradop/ui-core` package. Including this directive at the top level of the package was causing rendering issues in applications using Server Components—particularly in Next.js—because it forces the file to be treated as a Client Component, preventing its usage in server-rendered environments.

This issue was identified while integrating the library into a Next.js project, which distinguishes between client and server components using `"use client"` and `"use server"` directives.

By removing the directive, we restore compatibility with server-side rendering (SSR) and allow developers to apply `"use client"` only where needed in their own application code.

## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code.
- [x] All tests have been added and pass successfully.

## Notes


