### PR TITLE
chore(config): add `prettier` config and remove unnecessary configs

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -9,6 +9,7 @@ This directory contains shared configuration packages that ensure consistency an
 ## Available Packages
 
 - [`@ui/eslint-config`](./eslint-config/README.md): Modern ESLint 9.x configuration with React 19, TypeScript, and accessibility support.
+- [`@ui/prettier-config`](./prettier-config/README.md): Opinionated Prettier configuration for consistent code formatting across all projects.
 - [`@ui/tailwind-config`](./tailwind-config/README.md): Design system foundation with TailwindCSS v4 theme tokens and global styles.
 - [`@ui/ts-config`](./ts-config/README.md): TypeScript compiler configurations for different project types and environments.
 - [`@ui/tsup-config`](./tsup-config/README.md): Unified build configuration for fast, consistent package bundling.

--- a/configs/eslint-config/README.md
+++ b/configs/eslint-config/README.md
@@ -1,6 +1,6 @@
 # @ui/eslint-config
 
-> Shared ESLint configuration for the @halvaradop/ui library monorepo
+> Shared ESLint configuration for the [`@halvaradop/ui`](https://github.com/halvaradop/ui) monorepo
 
 A comprehensive ESLint configuration optimized for React 19, TypeScript, and modern JavaScript development. Designed specifically for component libraries and monorepo environments with accessibility, Prettier integration, and Turbo support.
 
@@ -120,9 +120,10 @@ eslint . --cache --cache-location .cache/.eslintcache
 
 ## Related Packages
 
-- [`@ui/ts-config`](../ts-config) - TypeScript compiler options
-- [`@ui/tsup-config`](../tsup-config) - Build and bundling configuration
-- [`@ui/tailwind-config`](../tailwind-config) - Styling and design tokens
+- [`@ui/prettier-config`](../prettier-config/) — Shared Prettier configuration
+- [`@ui/tailwind-config`](../tailwind-config) — Tailwind CSS and design tokens
+- [`@ui/ts-config`](../ts-config) — TypeScript compiler settings
+- [`@ui/tsup-config`](../tsup-config) — Build and bundling setup
 
 ## License
 

--- a/configs/prettier-config/README.md
+++ b/configs/prettier-config/README.md
@@ -1,0 +1,57 @@
+# @ui/prettier-config
+
+> Shared Prettier configuration for the [`@halvaradop/ui`](https://github.com/halvaradop/ui) monorepo
+
+## Overview
+
+This package provides a consistent Prettier setup for all projects in the `@ui` workspace.
+
+## Installation
+
+Install as a development dependency within your package:
+
+```bash
+pnpm add -D @ui/prettier-config
+```
+
+## Usage
+
+### Basic Setup
+
+Create a `prettier.config.js` file in your package root:
+
+```js
+import { config } from "@ui/prettier-config";
+
+/** @type {import("prettier").Config} */
+export default config;
+```
+
+### Customization
+
+You can extend the shared config with your own overrides:
+
+```js
+import { config } from "@ui/prettier-config";
+
+export default {
+  ...config,
+  overrides: [
+    // Add custom rules here
+  ],
+};
+```
+
+> **Note:** The property is `overrides`, not `overides`.
+
+## Related Packages
+
+- [`@ui/eslint-config`](../eslint-config/) — Shared ESLint configuration
+- [`@ui/prettier-config`](../prettier-config/) — Shared Prettier configuration
+- [`@ui/tailwind-config`](../tailwind-config) — Tailwind CSS and design tokens
+- [`@ui/ts-config`](../ts-config) — TypeScript compiler settings
+- [`@ui/tsup-config`](../tsup-config) — Build and bundling setup
+
+## License
+
+MIT — See the [LICENSE](../../LICENSE) file for details.

--- a/configs/prettier-config/package.json
+++ b/configs/prettier-config/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@ui/prettier-config",
+  "version": "0.0.0",
+  "private": false,
+  "description": "Prettier configuration package for @ui library components.",
+  "type": "module",
+  "scripts": {
+    "format": "prettier --write . --cache --cache-location .cache/.prettiercache",
+    "format:check": "prettier --check .",
+    "lint": "eslint . --cache --cache-location .cache/.eslintcache",
+    "lint:fix": "eslint . --fix --cache --cache-location .cache/.eslintcache",
+    "clean": "pnpm clean:modules && pnpm clean:turbo",
+    "clean:modules": "rm -rf node_modules",
+    "clean:turbo": "rm -rf .turbo"
+  },
+  "keywords": [
+    "prettier",
+    "config",
+    "ui"
+  ],
+  "author": "Hernan Alvarado <hernanvid123@gmail.com>",
+  "license": "MIT",
+  "exports": {
+    ".": "./prettier.config.js",
+    "./prettier.config.js": "./prettier.config.js"
+  }
+}

--- a/configs/prettier-config/prettier.config.js
+++ b/configs/prettier-config/prettier.config.js
@@ -1,0 +1,17 @@
+/**
+ * @type {import("prettier").Config}
+ */
+export const config = {
+  semi: false,
+  tabWidth: 4,
+  printWidth: 120,
+  trailingComma: "es5",
+  overrides: [
+    {
+      files: ["*.json", "*.md", "*.yaml", "*.yml"],
+      options: {
+        tabWidth: 2,
+      },
+    },
+  ],
+};

--- a/configs/tailwind-config/README.md
+++ b/configs/tailwind-config/README.md
@@ -1,6 +1,6 @@
 # @ui/tailwind-config
 
-> Shared TailwindCSS configuration and global styles for the @ui library monorepo
+> Shared TailwindCSS configuration and global styles for the [`@halvaradop/ui`](https://github.com/halvaradop/ui) monorepo
 
 This package provides a comprehensive TailwindCSS v4+ configuration with custom design tokens, dark mode support, and component-optimized styles. It includes a global CSS file with theme variables and responsive design tokens optimized for UI component libraries.
 
@@ -52,9 +52,10 @@ The configuration includes a comprehensive color system using OKLCH color space 
 
 ## Related Packages
 
-- [`@ui/ts-config`](../ts-config) - TypeScript compiler options
-- [`@ui/tsup-config`](../tsup-config) - Build and bundling configuration
-- [`@ui/tailwind-config`](../tailwind-config) - Styling and design tokens
+- [`@ui/eslint-config`](../eslint-config/) — Shared ESLint configuration
+- [`@ui/prettier-config`](../prettier-config/) — Shared Prettier configuration
+- [`@ui/ts-config`](../ts-config) — TypeScript compiler settings
+- [`@ui/tsup-config`](../tsup-config) — Build and bundling setup
 
 ## License
 

--- a/configs/ts-config/README.md
+++ b/configs/ts-config/README.md
@@ -1,6 +1,6 @@
 # @ui/ts-config
 
-> Shared TypeScript configurations for the @halvaradop/ui library monorepo
+> Shared TypeScript configurations for the [`@halvaradop/ui`](https://github.com/halvaradop/ui) monorepo
 
 This package provides standardized TypeScript configurations optimized for React component development, Node.js environments, and monorepo structures. It includes multiple configuration presets for different use cases.
 
@@ -38,9 +38,10 @@ Most common usage for React components:
 
 ## Related Packages
 
-- [`@ui/ts-config`](../ts-config) - TypeScript compiler options
-- [`@ui/tsup-config`](../tsup-config) - Build and bundling configuration
-- [`@ui/tailwind-config`](../tailwind-config) - Styling and design tokens
+- [`@ui/eslint-config`](../eslint-config/) — Shared ESLint configuration
+- [`@ui/prettier-config`](../prettier-config/) — Shared Prettier configuration
+- [`@ui/tailwind-config`](../tailwind-config) — Tailwind CSS and design tokens
+- [`@ui/tsup-config`](../tsup-config) — Build and bundling setup
 
 ## License
 

--- a/configs/tsup-config/README.md
+++ b/configs/tsup-config/README.md
@@ -1,6 +1,6 @@
 # @ui/tsup-config
 
-> Shared TSup build configuration for the @halvaradop/ui library monorepo
+> Shared TSup build configuration for the [`@halvaradop/ui`](https://github.com/halvaradop/ui) monorepo
 
 This package provides a standardized TSup configuration for building TypeScript packages in the @halvaradop/ui monorepo. It includes optimized settings for React components, libraries, and modern JavaScript development.
 
@@ -47,9 +47,10 @@ export default defineConfig({
 
 ## Related Packages
 
-- [`@ui/ts-config`](../ts-config) - TypeScript compiler options
-- [`@ui/tsup-config`](../tsup-config) - Build and bundling configuration
-- [`@ui/tailwind-config`](../tailwind-config) - Styling and design tokens
+- [`@ui/eslint-config`](../eslint-config/) — Shared ESLint configuration
+- [`@ui/prettier-config`](../prettier-config/) — Shared Prettier configuration
+- [`@ui/tailwind-config`](../tailwind-config) — Tailwind CSS and design tokens
+- [`@ui/ts-config`](../ts-config) — TypeScript compiler settings
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "homepage": "https://github.com/halvaradop/ui#readme",
   "devDependencies": {
     "@ui/eslint-config": "workspace:*",
+    "@ui/prettier-config": "workspace:*",
     "@ui/ts-config": "workspace:*",
     "@playwright/test": "^1.51.0",
     "@storybook/blocks": "^8.6.4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,26 +5,14 @@ import { defineConfig, devices } from "@playwright/test"
  */
 export default defineConfig({
     testDir: "tests",
-    /* Run tests in files in parallel */
     fullyParallel: true,
-    /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
-    /* Retry on CI only */
     retries: process.env.CI ? 2 : 0,
-    /* Opt out of parallel tests on CI. */
     workers: process.env.CI ? 1 : undefined,
-    /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: "html",
-    /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
-        /* Base URL to use in actions like `await page.goto('/')`. */
-        // baseURL: 'http://127.0.0.1:3000',
-
-        /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: "on-first-retry",
     },
-
-    /* Configure projects for major browsers */
     projects: [
         {
             name: "chromium",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       "@ui/eslint-config":
         specifier: workspace:*
         version: link:configs/eslint-config
+      "@ui/prettier-config":
+        specifier: workspace:*
+        version: link:configs/prettier-config
       "@ui/ts-config":
         specifier: workspace:*
         version: link:configs/ts-config
@@ -160,6 +163,8 @@ importers:
       typescript-eslint:
         specifier: ^8.35.0
         version: 8.35.0(eslint@9.30.0(jiti@2.4.2))(typescript@5.8.3)
+
+  configs/prettier-config: {}
 
   configs/tailwind-config:
     devDependencies:

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,19 +1,4 @@
-/**
- * @type {import("prettier").Config}
- */
-const config = {
-    semi: false,
-    tabWidth: 4,
-    printWidth: 120,
-    trailingComma: "es5",
-    overrides: [
-        {
-            files: ["*.json", "*.md", "*.yaml", "*.yml"],
-            options: {
-                tabWidth: 2,
-            },
-        },
-    ],
-}
+import { config } from "@ui/prettier-config"
 
+/** @type {import("prettier").Config} */
 export default config

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,9 +1,0 @@
-{
-  "extends": "@ui/ts-config/tsconfig.base.json",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@/ui/*": ["./packages/*"]
-    }
-  }
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "files": [],
-  "references": [{ "path": "./tsconfig.base.json" }],
-  "compilerOptions": {
-    "paths": {
-      "@/ui/*": ["./packages/*"]
-    }
-  }
-}


### PR DESCRIPTION
## Description

This pull request introduces a `prettier-config` package within the `configs` directory to centralize and share the Prettier configuration across the entire monorepo. This promotes consistency in code formatting and makes maintenance easier.

Additionally, it removes unnecessary TypeScript configuration files from the root directory that were not being used by any package in the monorepo, helping to reduce clutter and confusion.


## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [ ] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
